### PR TITLE
Use Foundry profile for ir

### DIFF
--- a/.github/workflows/gas-snapshot.yml
+++ b/.github/workflows/gas-snapshot.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           set -euo pipefail
           # grep -E '^test'  -- skip over test results, just get diffs
-          forge snapshot --via-ir --diff \
+          FOUNDRY_PROFILE=ir forge snapshot --diff \
             | grep -E '^test'   \
             | tee .gas-snapshot.new
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,12 +30,12 @@ jobs:
       - name: Run Forge build
         run: |
           forge --version
-          forge build --via-ir --sizes
+          FOUNDRY_PROFILE=ir forge build --sizes
         id: build
 
       - name: Run Forge tests
         run: |
-          forge test --via-ir
+          FOUNDRY_PROFILE=ir forge test
         id: test
         env:
           NODE_PROVIDER_BYPASS_KEY: ${{ secrets.NODE_PROVIDER_BYPASS_KEY }}

--- a/script/deploy-quark-scripts.sh
+++ b/script/deploy-quark-scripts.sh
@@ -20,7 +20,7 @@ else
   etherscan_args=""
 fi
 
-forge script --via-ir \
+FOUNDRY_PROFILE=ir forge script \
     $rpc_args \
     $wallet_args \
     $etherscan_args \

--- a/script/prepare-release.sh
+++ b/script/prepare-release.sh
@@ -14,7 +14,7 @@ artifact_name="quark-scripts-out.${release_name}.zip"
 artifact_note="Compiled ABI"
 
 printf 'building full project...\n'
-forge build --via-ir
+FOUNDRY_PROFILE=ir forge build
 
 printf 'preparing release archive "%s"...\n' ${release_name}
 zip --recurse-paths "${artifact_name}" out/*

--- a/script/update-snapshot.sh
+++ b/script/update-snapshot.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-forge snapshot --via-ir
+FOUNDRY_PROFILE=ir forge snapshot


### PR DESCRIPTION
The gas snapshot CI action was failing because the project's `via-ir` settings were moved to a new Foundry profile, but our scripts and CI actions were not modified to use the Foundry profile.