### PR TITLE
Add bridge type to action context

### DIFF
--- a/src/builder/Actions.sol
+++ b/src/builder/Actions.sol
@@ -19,6 +19,8 @@ library Actions {
     string constant ACTION_TYPE_BRIDGE = "BRIDGE";
     string constant ACTION_TYPE_TRANSFER = "TRANSFER";
 
+    string constant BRIDGE_TYPE_CCTP = "CCTP";
+
     uint256 constant TRANSFER_EXPIRY_BUFFER = 7 days;
     uint256 constant BRIDGE_EXPIRY_BUFFER = 7 days;
 
@@ -82,6 +84,7 @@ library Actions {
         uint256 chainId;
         address recipient;
         uint256 destinationChainId;
+        string bridgeType;
     }
 
     function bridgeAsset(BridgeAsset memory bridge)
@@ -134,7 +137,8 @@ library Actions {
             token: srcUSDCPositions.asset,
             chainId: bridge.srcChainId,
             recipient: bridge.recipient,
-            destinationChainId: bridge.destinationChainId
+            destinationChainId: bridge.destinationChainId,
+            bridgeType: BRIDGE_TYPE_CCTP
         });
         Action memory action = Actions.Action({
             chainId: bridge.srcChainId,

--- a/src/builder/PaycallWrapper.sol
+++ b/src/builder/PaycallWrapper.sol
@@ -25,7 +25,7 @@ library PaycallWrapper {
 
         return IQuarkWallet.QuarkOperation({
             nonce: operation.nonce,
-            scriptAddress: CodeJarHelper.getCodeAddress(chainId, paycallSource),
+            scriptAddress: CodeJarHelper.getCodeAddress(paycallSource),
             scriptCalldata: abi.encodeWithSelector(
                 Paycall.run.selector, operation.scriptAddress, operation.scriptCalldata, maxPaymentCost
                 ),

--- a/test/PaycallWrapper.t.sol
+++ b/test/PaycallWrapper.t.sol
@@ -37,7 +37,7 @@ contract PaycallWrapperTest is Test {
         scriptSources[0] = type(TransferActions).creationCode;
         IQuarkWallet.QuarkOperation memory op = IQuarkWallet.QuarkOperation({
             nonce: wallet.stateManager().nextNonce(address(wallet)),
-            scriptAddress: CodeJarHelper.getCodeAddress(1, type(TransferActions).creationCode),
+            scriptAddress: CodeJarHelper.getCodeAddress(type(TransferActions).creationCode),
             scriptCalldata: abi.encodeWithSelector(TransferActions.transferERC20Token.selector, USDC, address(this), 10e6),
             scriptSources: scriptSources,
             expiry: 99999999999
@@ -51,7 +51,7 @@ contract PaycallWrapperTest is Test {
         assertEq(
             wrappedPaycallOp.scriptAddress,
             CodeJarHelper.getCodeAddress(
-                1, abi.encodePacked(type(Paycall).creationCode, abi.encode(ETH_USD_PRICE_FEED, USDC))
+                abi.encodePacked(type(Paycall).creationCode, abi.encode(ETH_USD_PRICE_FEED, USDC))
             ),
             "script address should be paycall"
         );

--- a/test/QuarkBuilder.t.sol
+++ b/test/QuarkBuilder.t.sol
@@ -211,7 +211,8 @@ contract QuarkBuilderTest is Test {
                     token: USDC_1,
                     chainId: 1,
                     recipient: address(0xa11ce),
-                    destinationChainId: 8453
+                    destinationChainId: 8453,
+                    bridgeType: Actions.BRIDGE_TYPE_CCTP
                 })
             ),
             "action context encoded from BridgeActionContext"


### PR DESCRIPTION
We add `bridgeType` to the action context for bridge actions. I also fix some unrelated issues in the paycall code.