### PR TITLE
Remove unnecessary fields in structs

### DIFF
--- a/src/builder/Accounts.sol
+++ b/src/builder/Accounts.sol
@@ -15,9 +15,6 @@ library Accounts {
     // the client encoding that much simpler.
     struct QuarkState {
         address account;
-        bool hasCode;
-        bool isQuark;
-        string quarkVersion;
         uint96 quarkNextNonce;
     }
 

--- a/src/builder/QuarkBuilder.sol
+++ b/src/builder/QuarkBuilder.sol
@@ -38,11 +38,9 @@ contract QuarkBuilder {
         IQuarkWallet.QuarkOperation[] quarkOperations;
         // array of action context and other metadata corresponding 1:1 with quarkOperations
         Actions.Action[] actions;
-        // EIP-712 digest to sign for a MultiQuarkOperation to fulfill the client intent.
-        // Empty when quarkOperations.length == 0.
-        bytes32 multiQuarkOperationDigest;
-        // EIP-712 digest to sign for a single QuarkOperation to fulfill the client intent.
-        // Empty when quarkOperations.length != 1.
+        // EIP-712 digest to sign for either a MultiQuarkOperation or a single QuarkOperation to fulfill the client intent.
+        // The digest will be for a MultiQuarkOperation if there are more than one QuarkOperations in the BuilderResult.
+        // Otherwise, the digest will be for a single QuarkOperation.
         bytes32 quarkOperationDigest;
         // client-provided paymentCurrency string that was used to derive token addresses.
         // client may re-use this string to construct a request that simulates the transaction.
@@ -181,12 +179,11 @@ contract QuarkBuilder {
         assertActionsAffordable(actions, chainAccountsList, transferIntent);
 
         bytes32 quarkOperationDigest;
-        bytes32 multiQuarkOperationDigest;
         if (quarkOperations.length == 1) {
             quarkOperationDigest =
                 EIP712Helper.getDigestForQuarkOperation(quarkOperations[0], actions[0].quarkAccount, actions[0].chainId);
         } else if (quarkOperations.length > 1) {
-            multiQuarkOperationDigest = EIP712Helper.getDigestForMultiQuarkOperation(quarkOperations, actions);
+            quarkOperationDigest = EIP712Helper.getDigestForMultiQuarkOperation(quarkOperations, actions);
         }
 
         return BuilderResult({
@@ -194,7 +191,6 @@ contract QuarkBuilder {
             actions: actions,
             quarkOperations: quarkOperations,
             paymentCurrency: payment.currency,
-            multiQuarkOperationDigest: multiQuarkOperationDigest,
             quarkOperationDigest: quarkOperationDigest
         });
     }

--- a/test/QuarkBuilder.t.sol
+++ b/test/QuarkBuilder.t.sol
@@ -117,8 +117,8 @@ contract QuarkBuilderTest is Test {
             "action context encoded from TransferActionContext"
         );
 
-        assertNotEq(result.quarkOperationDigest, hex"", "non-empty single digest");
-        assertEq(result.multiQuarkOperationDigest, hex"", "empty multi digest");
+        // TODO: Check the contents of the digest
+        assertNotEq(result.quarkOperationDigest, hex"", "non-empty digest");
     }
 
     function testSimpleLocalTransferWithPaycallSucceeds() public {
@@ -308,8 +308,8 @@ contract QuarkBuilderTest is Test {
             "action context encoded from TransferActionContext"
         );
 
-        assertEq(result.quarkOperationDigest, hex"", "empty single digest");
-        assertNotEq(result.multiQuarkOperationDigest, hex"", "non-empty multi digest");
+        // TODO: Check the contents of the digest
+        assertNotEq(result.quarkOperationDigest, hex"", "non-empty digest");
     }
 
     function testSimpleBridgeTransferWithPaycallSucceeds() public {
@@ -544,12 +544,6 @@ contract QuarkBuilderTest is Test {
     }
 
     function quarkState_(address account, uint96 nextNonce) internal pure returns (Accounts.QuarkState memory) {
-        return Accounts.QuarkState({
-            account: account,
-            hasCode: true,
-            isQuark: true,
-            quarkVersion: "1",
-            quarkNextNonce: nextNonce
-        });
+        return Accounts.QuarkState({account: account, quarkNextNonce: nextNonce});
     }
 }


### PR DESCRIPTION
This PR removes unused fields from `QuarkState` and slims down `BuilderResult` to have a single digest instead of both `multiQuarkOperationDigest` and `quarkOperationDigest`.