### PR TITLE
Add QuarkBuilderHelper

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ Callbacks need to be explicitly turned on by Quark scripts. Specifically, this i
 
 ## Quark Builder
 
-[Quark Builder](./src/builder/QuarkBuilder.sol) is a library of functions that simplifies the complexities around building _Quark operations_. The code is written in Solidity, but not meant to be deployed on-chain. Rather, it is designed to run locally in a client to construct _Quark operations_ based on user intents (e.g. "transfer 5 USDC to 0xABC... on chain 10").
+[Quark Builder](./src/builder/QuarkBuilder.sol) is a contract of functions that simplifies the complexities around building _Quark operations_. The code is written in Solidity, but not meant to be deployed on-chain. Rather, it is designed to run locally in a client to construct _Quark operations_ based on user intents (e.g. "transfer 5 USDC to 0xABC... on chain 10").
+
+[Quark Builder Helper](./src/builder/QuarkBuilderHelper.sol) is a contract with functions outside of constructing _Quark operations_ that might still be helpful for those using the QuarkBuilder. For example, there is a helper function to determine the bridgeability of assets on different chains.
 
 ## Fork tests and NODE_PROVIDER_BYPASS_KEY
 

--- a/src/builder/QuarkBuilderHelper.sol
+++ b/src/builder/QuarkBuilderHelper.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity ^0.8.23;
+
+import {BridgeRoutes} from "./BridgeRoutes.sol";
+
+/**
+ * @title Quark Builder Helper
+ * @notice External-facing functions that might be helpful for those using the QuarkBuilder
+ */
+contract QuarkBuilderHelper {
+    /* ===== Constants ===== */
+
+    uint256 constant PAYMENT_COST_BUFFER = 1.2e18;
+    uint256 constant BUFFER_SCALE = 1e18;
+
+    function canBridge(uint256 srcChainId, uint256 dstChainId, string memory assetSymbol)
+        external
+        pure
+        returns (bool)
+    {
+        return BridgeRoutes.canBridge(srcChainId, dstChainId, assetSymbol);
+    }
+
+    function addBufferToPaymentCost(uint256 maxPaymentCost) external pure returns (uint256) {
+        return maxPaymentCost * PAYMENT_COST_BUFFER / BUFFER_SCALE;
+    }
+}

--- a/test/builder/QuarkBuilderHelper.t.sol
+++ b/test/builder/QuarkBuilderHelper.t.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity ^0.8.23;
+
+import "forge-std/Test.sol";
+
+import {QuarkBuilderHelper} from "src/builder/QuarkBuilderHelper.sol";
+
+contract QuarkBuilderHelperTest is Test {
+    function testCanBridgeUSDCOnSupportedChains() public {
+        QuarkBuilderHelper helper = new QuarkBuilderHelper();
+
+        assertEq(helper.canBridge(1, 8453, "USDC"), true);
+    }
+
+    function testCannotBridgeUSDCOnUnsupportedChains() public {
+        QuarkBuilderHelper helper = new QuarkBuilderHelper();
+
+        assertEq(helper.canBridge(999, 8453, "USDC"), false);
+    }
+
+    function testCannotBridgeUnsupportedAssets() public {
+        QuarkBuilderHelper helper = new QuarkBuilderHelper();
+
+        assertEq(helper.canBridge(1, 8453, "not_supported"), false);
+    }
+
+    function testAddBufferToPaymentCost() public {
+        QuarkBuilderHelper helper = new QuarkBuilderHelper();
+
+        assertEq(helper.addBufferToPaymentCost(0), 0);
+        assertEq(helper.addBufferToPaymentCost(5_000_000), 6_000_000);
+        assertEq(helper.addBufferToPaymentCost(98_384_506), 118_061_407);
+    }
+}


### PR DESCRIPTION
`QuarkBuilderHelper` is a contract of helper functions that might be useful for clients using the `QuarkBuilder`.