### PR TITLE
add husks to get actionContext abis

### DIFF
--- a/src/builder/Actions.sol
+++ b/src/builder/Actions.sol
@@ -268,4 +268,17 @@ library Actions {
         }
         return result;
     }
-}
+
+    // These structs are mostly used internally and returned in serialzed format as bytes: actionContext
+    // The caller can then decode them back into their struct form.
+    // These empty husk functions exist so that the structs make it into the abi so the clients can know how to decode them.
+    function emptyTransferActionContext() external pure returns (TransferActionContext memory) {
+      TransferActionContext[] memory ts = new TransferActionContext[](1);
+      return ts[0];
+    }
+
+    function emptyBridgeActionContext() external pure returns (BridgeActionContext memory) {
+      BridgeActionContext[] memory bs = new BridgeActionContext[](1);
+      return bs[0];
+    }
+ }

--- a/src/builder/Actions.sol
+++ b/src/builder/Actions.sol
@@ -269,16 +269,16 @@ library Actions {
         return result;
     }
 
-    // These structs are mostly used internally and returned in serialzed format as bytes: actionContext
+    // These structs are mostly used internally and returned in serialized format as bytes: actionContext
     // The caller can then decode them back into their struct form.
     // These empty husk functions exist so that the structs make it into the abi so the clients can know how to decode them.
     function emptyTransferActionContext() external pure returns (TransferActionContext memory) {
-      TransferActionContext[] memory ts = new TransferActionContext[](1);
-      return ts[0];
+        TransferActionContext[] memory ts = new TransferActionContext[](1);
+        return ts[0];
     }
 
     function emptyBridgeActionContext() external pure returns (BridgeActionContext memory) {
-      BridgeActionContext[] memory bs = new BridgeActionContext[](1);
-      return bs[0];
+        BridgeActionContext[] memory bs = new BridgeActionContext[](1);
+        return bs[0];
     }
- }
+}


### PR DESCRIPTION
The ABIs for these structs are things that clients depend upon, but they are not available from the compiled abi as they are serialized before being given as a return value. These simple functions serve to get their abis into the out/actions.sol/actions.json.