### PR TITLE
Ignore chain if no max cost

### DIFF
--- a/src/builder/Accounts.sol
+++ b/src/builder/Accounts.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 pragma solidity ^0.8.23;
 
+import {PaymentInfo} from "./PaymentInfo.sol";
 import {Strings} from "./Strings.sol";
 
 library Accounts {
@@ -99,6 +100,22 @@ library Accounts {
         }
     }
 
+    function findChainAccountsWithPaymentInfo(
+        ChainAccounts[] memory chainAccountsList,
+        PaymentInfo.Payment memory payment
+    ) internal pure returns (ChainAccounts[] memory found) {
+        ChainAccounts[] memory filteredAccounts = new ChainAccounts[](chainAccountsList.length);
+        uint256 count = 0;
+
+        for (uint256 i = 0; i < chainAccountsList.length; ++i) {
+            if (PaymentInfo.hasMaxCostForChain(payment, chainAccountsList[i].chainId)) {
+                filteredAccounts[count++] = chainAccountsList[i];
+            }
+        }
+
+        return truncate(filteredAccounts, count);
+    }
+
     function sumBalances(AssetPositions memory assetPositions) internal pure returns (uint256) {
         uint256 totalBalance = 0;
         for (uint256 i = 0; i < assetPositions.accountBalances.length; ++i) {
@@ -114,5 +131,17 @@ library Accounts {
     {
         AssetPositions memory positions = findAssetPositions(assetSymbol, chainId, chainAccountsList);
         return sumBalances(positions);
+    }
+
+    function truncate(ChainAccounts[] memory chainAccountsList, uint256 length)
+        internal
+        pure
+        returns (ChainAccounts[] memory)
+    {
+        ChainAccounts[] memory result = new ChainAccounts[](length);
+        for (uint256 i = 0; i < length; ++i) {
+            result[i] = chainAccountsList[i];
+        }
+        return result;
     }
 }

--- a/src/builder/PaymentInfo.sol
+++ b/src/builder/PaymentInfo.sol
@@ -11,6 +11,7 @@ library PaymentInfo {
         bool isToken;
         // Note: Payment `currency` should be the same across chains
         string currency;
+        // Note: If max cost is not specified for a chain when paying with token, then that chain is ignored
         PaymentMaxCost[] maxCosts;
     }
 
@@ -65,5 +66,14 @@ library PaymentInfo {
             }
         }
         revert MaxCostMissingForChain(chainId);
+    }
+
+    function hasMaxCostForChain(Payment memory payment, uint256 chainId) internal pure returns (bool) {
+        for (uint256 i = 0; i < payment.maxCosts.length; ++i) {
+            if (payment.maxCosts[i].chainId == chainId) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/test/QuarkBuilder.t.sol
+++ b/test/QuarkBuilder.t.sol
@@ -24,7 +24,7 @@ contract QuarkBuilderTest is Test {
 
     function testInsufficientFunds() public {
         QuarkBuilder builder = new QuarkBuilder();
-        vm.expectRevert(QuarkBuilder.InsufficientFunds.selector);
+        vm.expectRevert(abi.encodeWithSelector(QuarkBuilder.InsufficientFunds.selector, 10e6, 0e6));
         builder.transfer(
             transferUsdc_(1, 10e6, address(0xfe11a), BLOCK_TIMESTAMP), // transfer 10USDC on chain 1 to 0xfe11a
             chainAccountsList_(0e6), // but we are holding 0 USDC in total across 1, 8453
@@ -442,8 +442,8 @@ contract QuarkBuilderTest is Test {
 
         // Note: There are 3e6 USDC on each chain, so the Builder should attempt to bridge 2 USDC to chain 8453.
         // However, max cost is not specified for chain 1, so the Builder will ignore the chain and revert because
-        // not enough funds are available for the transfer.
-        vm.expectRevert(QuarkBuilder.FundsUnavailable.selector);
+        // there will be insufficient funds for the transfer.
+        vm.expectRevert(abi.encodeWithSelector(QuarkBuilder.InsufficientFunds.selector, 5e6, 3e6));
         builder.transfer(
             transferUsdc_(8453, 5e6, address(0xceecee), BLOCK_TIMESTAMP), // transfer 5 USDC on chain 8453 to 0xceecee
             chainAccountsList_(6e6), // holding 6 USDC in total across chains 1, 8453


### PR DESCRIPTION
If the action is paid for with tokens and max cost is not specified for a chain, then the Builder will now ignore that chain instead of reverting. This allows clients to indicate the chains an action can utilize.