### PR TITLE
CometSupply

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,6 @@ jobs:
       - name: Run Forge build
         run: |
           forge --version
-          forge build --sizes
         id: build
 
       - name: Run Forge Format

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,6 @@ jobs:
       - name: Run Forge build
         run: |
           forge --version
-          forge build --sizes
         id: build
 
       - name: Run Forge tests

--- a/src/builder/Actions.sol
+++ b/src/builder/Actions.sol
@@ -317,7 +317,7 @@ library Actions {
         }
 
         // Construct Action
-        CometSupplyActionContext memory cometSupplyActionContext = CometSupplyActionContext({
+        SupplyActionContext memory cometSupplyActionContext = SupplyActionContext({
             amount: cometSupply.amount,
             chainId: cometSupply.chainId,
             comet: cometSupply.comet,
@@ -327,7 +327,7 @@ library Actions {
         Action memory action = Actions.Action({
             chainId: cometSupply.chainId,
             quarkAccount: cometSupply.sender,
-            actionType: ACTION_TYPE_COMET_SUPPLY,
+            actionType: ACTION_TYPE_SUPPLY,
             actionContext: abi.encode(cometSupplyActionContext),
             paymentMethod: payment.isToken ? PAYMENT_METHOD_PAYCALL : PAYMENT_METHOD_OFFCHAIN,
             // Null address for OFFCHAIN payment.

--- a/src/builder/Actions.sol
+++ b/src/builder/Actions.sol
@@ -48,12 +48,12 @@ library Actions {
 
     struct CometSupply {
         Accounts.ChainAccounts[] chainAccountsList;
-        uint256 amount;
         string assetSymbol;
-        uint256 blockTimestamp;
+        uint256 amount;
         uint256 chainId;
         address comet;
         address sender;
+        uint256 blockTimestamp;
     }
 
     struct TransferAsset {

--- a/src/builder/QuarkBuilder.sol
+++ b/src/builder/QuarkBuilder.sol
@@ -23,6 +23,7 @@ contract QuarkBuilder {
     error AssetPositionNotFound();
     error FundsUnavailable(uint256 requiredAmount, uint256 actualAmount, uint256 missingAmount);
     error InsufficientFunds(uint256 requiredAmount, uint256 actualAmount);
+    error InvalidActionChain();
     error InvalidActionType();
     error InvalidInput();
     error MaxCostTooHigh();
@@ -528,8 +529,10 @@ contract QuarkBuilder {
         uint256 paymentTokenCost = 0;
 
         for (uint256 i = 0; i < nonBridgeActions.length; ++i) {
-            // revert if not on the target chain?
             Actions.Action memory nonBridgeAction = nonBridgeActions[i];
+            if (nonBridgeAction.chainId != targetChainId) {
+                revert InvalidActionChain();
+            }
             paymentTokenCost += nonBridgeAction.paymentMaxCost;
 
             if (Strings.stringEqIgnoreCase(nonBridgeAction.actionType, Actions.ACTION_TYPE_TRANSFER)) {

--- a/src/builder/QuarkBuilder.sol
+++ b/src/builder/QuarkBuilder.sol
@@ -59,6 +59,7 @@ contract QuarkBuilder {
         address sender;
     }
 
+    // TODO: handle supply max
     function cometSupply(
         CometSupplyIntent memory cometSupplyIntent,
         Accounts.ChainAccounts[] memory chainAccountsList,

--- a/test/QuarkBuilderCometSupply.t.sol
+++ b/test/QuarkBuilderCometSupply.t.sol
@@ -1,0 +1,447 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity ^0.8.23;
+
+import "forge-std/Test.sol";
+import "forge-std/console.sol";
+
+import {Actions} from "../src/builder/Actions.sol";
+import {CCTPBridgeActions} from "../src/BridgeScripts.sol";
+import {CodeJarHelper} from "../src/builder/CodeJarHelper.sol";
+import {CometSupplyActions, TransferActions} from "../src/DeFiScripts.sol";
+import {Paycall} from "../src/Paycall.sol";
+
+import "./lib/QuarkBuilderTest.sol";
+
+contract QuarkBuilderCometSupplyTest is Test, QuarkBuilderTest {
+    uint256 constant BLOCK_TIMESTAMP = 123_456_789;
+    address constant COMET = address(0xc3);
+
+    function cometSupply_(uint256 chainId, uint256 amount)
+        internal
+        pure
+        returns (QuarkBuilder.CometSupplyIntent memory)
+    {
+        return QuarkBuilder.CometSupplyIntent({
+            amount: amount,
+            assetSymbol: "USDC",
+            blockTimestamp: BLOCK_TIMESTAMP,
+            chainId: chainId,
+            comet: COMET,
+            sender: address(0xa11ce)
+        });
+    }
+
+    function testInsufficientFunds() public {
+        QuarkBuilder builder = new QuarkBuilder();
+        vm.expectRevert(abi.encodeWithSelector(QuarkBuilder.InsufficientFunds.selector, 2e6, 0e6));
+        builder.cometSupply(
+            cometSupply_(1, 2e6),
+            chainAccountsList_(0e6), // but we are holding 0 USDC in total across 1, 8453
+            paymentUsd_()
+        );
+    }
+
+    function testMaxCostTooHigh() public {
+        QuarkBuilder builder = new QuarkBuilder();
+        vm.expectRevert(QuarkBuilder.MaxCostTooHigh.selector);
+        builder.cometSupply(
+            cometSupply_(1, 1e6),
+            chainAccountsList_(2e6), // holding 2 USDC in total across 1, 8453
+            paymentUsdc_(maxCosts_(1, 1_000e6)) // but costs 1,000USDC
+        );
+    }
+
+    function testFundsUnavailable() public {
+        QuarkBuilder builder = new QuarkBuilder();
+        vm.expectRevert(QuarkBuilder.FundsUnavailable.selector);
+        builder.cometSupply(
+            // there is no bridge to chain 7777, so we cannot get to our funds
+            cometSupply_(7777, 2), // transfer 2USDC on chain 7777 to 0xfe11a
+            chainAccountsList_(3e6), // holding 3 USDC in total across chains 1, 8453
+            paymentUsd_()
+        );
+    }
+
+    function testSimpleCometSupply() public {
+        QuarkBuilder builder = new QuarkBuilder();
+        QuarkBuilder.BuilderResult memory result = builder.cometSupply(
+            cometSupply_(1, 2),
+            chainAccountsList_(3e6), // holding 3 USDC in total across chains 1, 8453
+            paymentUsd_()
+        );
+
+        assertEq(result.version, "1.0.0", "version 1");
+        assertEq(result.paymentCurrency, "usd", "usd currency");
+
+        // Check the quark operations
+        assertEq(result.quarkOperations.length, 1, "one operation");
+        assertEq(
+            result.quarkOperations[0].scriptAddress,
+            address(
+                uint160(
+                    uint256(
+                        keccak256(
+                            abi.encodePacked(
+                                bytes1(0xff),
+                                /* codeJar address */
+                                address(CodeJarHelper.CODE_JAR_ADDRESS),
+                                uint256(0),
+                                /* script bytecode */
+                                keccak256(type(CometSupplyActions).creationCode)
+                            )
+                        )
+                    )
+                )
+            ),
+            "script address is correct given the code jar address on mainnet"
+        );
+        assertEq(
+            result.quarkOperations[0].scriptCalldata,
+            abi.encodeCall(CometSupplyActions.supply, (COMET, usdc_(1), 2)),
+            "calldata is CometSupplyActions.supply(COMET, usdc, 2);"
+        );
+        assertEq(
+            result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
+        );
+
+        // check the actions
+        assertEq(result.actions.length, 1, "one action");
+        assertEq(result.actions[0].chainId, 1, "operation is on chainid 1");
+        assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
+        assertEq(result.actions[0].actionType, "COMET_SUPPLY", "action type is 'COMET_SUPPLY'");
+        assertEq(result.actions[0].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
+        assertEq(result.actions[0].paymentToken, address(0), "payment token is null");
+        assertEq(result.actions[0].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
+        assertEq(
+            result.actions[0].actionContext,
+            abi.encode(
+                Actions.CometSupplyActionContext({amount: 2, chainId: 1, comet: COMET, price: 1e8, token: USDC_1})
+            ),
+            "action context encoded from CometSupplyActionContext"
+        );
+
+        // TODO: Check the contents of the EIP712 data
+        assertNotEq(result.eip712Data.digest, hex"", "non-empty digest");
+        assertNotEq(result.eip712Data.domainSeparator, hex"", "non-empty domain separator");
+        assertNotEq(result.eip712Data.hashStruct, hex"", "non-empty hashStruct");
+    }
+
+    function testCometSupplyWithPaycall() public {
+        QuarkBuilder builder = new QuarkBuilder();
+        PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](1);
+        maxCosts[0] = PaymentInfo.PaymentMaxCost({chainId: 1, amount: 1e5});
+        QuarkBuilder.BuilderResult memory result = builder.cometSupply(
+            cometSupply_(1, 2),
+            chainAccountsList_(3e6), // holding 3 USDC in total across chains 1, 8453
+            paymentUsdc_(maxCosts)
+        );
+
+        address cometSupplyActionsAddress = CodeJarHelper.getCodeAddress(type(CometSupplyActions).creationCode);
+        address paycallAddress = CodeJarHelper.getCodeAddress(
+            abi.encodePacked(type(Paycall).creationCode, abi.encode(ETH_USD_PRICE_FEED_1, USDC_1))
+        );
+
+        assertEq(result.version, "1.0.0", "version 1");
+        assertEq(result.paymentCurrency, "usdc", "usdc currency");
+
+        // Check the quark operations
+        assertEq(result.quarkOperations.length, 1, "one operation");
+        assertEq(
+            result.quarkOperations[0].scriptAddress,
+            paycallAddress,
+            "script address is correct given the code jar address on mainnet"
+        );
+        assertEq(
+            result.quarkOperations[0].scriptCalldata,
+            abi.encodeWithSelector(
+                Paycall.run.selector,
+                cometSupplyActionsAddress,
+                abi.encodeWithSelector(CometSupplyActions.supply.selector, COMET, usdc_(1), 2),
+                1e5
+            ),
+            "calldata is Paycall.run(CometSupplyActions.supply(COMET, USDC, 2), 1e5);"
+        );
+        assertEq(
+            result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
+        );
+
+        // check the actions
+        assertEq(result.actions.length, 1, "one action");
+        assertEq(result.actions[0].chainId, 1, "operation is on chainid 1");
+        assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
+        assertEq(result.actions[0].actionType, "COMET_SUPPLY", "action type is 'COMET_SUPPLY'");
+        assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
+        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC");
+        assertEq(result.actions[0].paymentMaxCost, 1e5, "payment max is set to 1e5 in this test case");
+        assertEq(
+            result.actions[0].actionContext,
+            abi.encode(
+                Actions.CometSupplyActionContext({amount: 2, chainId: 1, comet: COMET, price: 1e8, token: USDC_1})
+            ),
+            "action context encoded from CometSupplyActionContext"
+        );
+
+        // TODO: Check the contents of the EIP712 data
+        assertNotEq(result.eip712Data.digest, hex"", "non-empty digest");
+        assertNotEq(result.eip712Data.domainSeparator, hex"", "non-empty domain separator");
+        assertNotEq(result.eip712Data.hashStruct, hex"", "non-empty hashStruct");
+    }
+
+    function testCometSupplyWithBridge() public {
+        QuarkBuilder builder = new QuarkBuilder();
+        QuarkBuilder.BuilderResult memory result = builder.cometSupply(
+            cometSupply_(8453, 5e6),
+            chainAccountsList_(6e6), // holding 3 USDC in total across chains 1, 8453
+            paymentUsd_()
+        );
+
+        assertEq(result.version, "1.0.0", "version 1");
+        assertEq(result.paymentCurrency, "usd", "usd currency");
+
+        // Check the quark operations
+        // first operation
+        assertEq(result.quarkOperations.length, 2, "two operations");
+        assertEq(
+            result.quarkOperations[0].scriptAddress,
+            address(
+                uint160(
+                    uint256(
+                        keccak256(
+                            abi.encodePacked(
+                                bytes1(0xff),
+                                /* codeJar address */
+                                address(CodeJarHelper.CODE_JAR_ADDRESS),
+                                uint256(0),
+                                /* script bytecode */
+                                keccak256(type(CCTPBridgeActions).creationCode)
+                            )
+                        )
+                    )
+                )
+            ),
+            "script address is correct given the code jar address on mainnet"
+        );
+        assertEq(
+            result.quarkOperations[0].scriptCalldata,
+            abi.encodeCall(
+                CCTPBridgeActions.bridgeUSDC,
+                (
+                    address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155),
+                    2e6,
+                    6,
+                    bytes32(uint256(uint160(0xa11ce))),
+                    usdc_(1)
+                )
+            ),
+            "calldata is CCTPBridgeActions.bridgeUSDC(address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155), 2e6, 6, bytes32(uint256(uint160(0xa11ce))), usdc_(1)));"
+        );
+        assertEq(
+            result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
+        );
+
+        // second operation
+        assertEq(
+            result.quarkOperations[1].scriptAddress,
+            address(
+                uint160(
+                    uint256(
+                        keccak256(
+                            abi.encodePacked(
+                                bytes1(0xff),
+                                /* codeJar address */
+                                address(CodeJarHelper.CODE_JAR_ADDRESS),
+                                uint256(0),
+                                /* script bytecode */
+                                keccak256(type(CometSupplyActions).creationCode)
+                            )
+                        )
+                    )
+                )
+            ),
+            "script address for transfer is correct given the code jar address"
+        );
+        assertEq(
+            result.quarkOperations[1].scriptCalldata,
+            abi.encodeCall(CometSupplyActions.supply, (COMET, usdc_(8453), 5e6)),
+            "calldata is CometSupplyActions.supply(COMET, usdc, 5e6);"
+        );
+        assertEq(
+            result.quarkOperations[1].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
+        );
+
+        // check the actions
+        // first action
+        assertEq(result.actions.length, 2, "two actions");
+        assertEq(result.actions[0].chainId, 1, "operation is on chainid 1");
+        assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
+        assertEq(result.actions[0].actionType, "BRIDGE", "action type is 'BRIDGE'");
+        assertEq(result.actions[0].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
+        assertEq(result.actions[0].paymentToken, address(0), "payment token is null");
+        assertEq(result.actions[0].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
+        assertEq(
+            result.actions[0].actionContext,
+            abi.encode(
+                Actions.BridgeActionContext({
+                    amount: 2e6,
+                    price: 1e8,
+                    token: USDC_1,
+                    chainId: 1,
+                    recipient: address(0xa11ce),
+                    destinationChainId: 8453,
+                    bridgeType: Actions.BRIDGE_TYPE_CCTP
+                })
+            ),
+            "action context encoded from BridgeActionContext"
+        );
+
+        // second action
+        assertEq(result.actions[1].chainId, 8453, "second action is on chainid 8453");
+        assertEq(result.actions[1].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
+        assertEq(result.actions[1].actionType, "COMET_SUPPLY", "action type is 'COMET_SUPPLY'");
+        assertEq(result.actions[1].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
+        assertEq(result.actions[1].paymentToken, address(0), "payment token is null");
+        assertEq(result.actions[1].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
+        assertEq(
+            result.actions[1].actionContext,
+            abi.encode(
+                Actions.CometSupplyActionContext({
+                    amount: 5e6,
+                    chainId: 8453,
+                    comet: COMET,
+                    price: 1e8,
+                    token: USDC_8453
+                })
+            ),
+            "action context encoded from CometSupplyActionContext"
+        );
+
+        // TODO: Check the contents of the EIP712 data
+        assertNotEq(result.eip712Data.digest, hex"", "non-empty digest");
+        assertNotEq(result.eip712Data.domainSeparator, hex"", "non-empty domain separator");
+        assertNotEq(result.eip712Data.hashStruct, hex"", "non-empty hashStruct");
+    }
+
+    function testCometSupplyWithBridgeAndPaycall() public {
+        QuarkBuilder builder = new QuarkBuilder();
+        PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](2);
+        maxCosts[0] = PaymentInfo.PaymentMaxCost({chainId: 1, amount: 5e5});
+        maxCosts[1] = PaymentInfo.PaymentMaxCost({chainId: 8453, amount: 1e5});
+
+        // Note: There are 3e6 USDC on each chain, so the Builder should attempt to bridge 2 USDC to chain 8453
+        QuarkBuilder.BuilderResult memory result = builder.cometSupply(
+            cometSupply_(8453, 5e6),
+            chainAccountsList_(6e6), // holding 3 USDC in total across chains 1, 8453
+            paymentUsdc_(maxCosts)
+        );
+
+        address paycallAddress = CodeJarHelper.getCodeAddress(
+            abi.encodePacked(type(Paycall).creationCode, abi.encode(ETH_USD_PRICE_FEED_1, USDC_1))
+        );
+        address paycallAddressBase = CodeJarHelper.getCodeAddress(
+            abi.encodePacked(type(Paycall).creationCode, abi.encode(ETH_USD_PRICE_FEED_8453, USDC_8453))
+        );
+        address cctpBridgeActionsAddress = CodeJarHelper.getCodeAddress(type(CCTPBridgeActions).creationCode);
+
+        assertEq(result.version, "1.0.0", "version 1");
+        assertEq(result.paymentCurrency, "usdc", "usd currency");
+
+        // Check the quark operations
+        assertEq(result.quarkOperations.length, 2, "two operations");
+        // first operation
+        assertEq(
+            result.quarkOperations[0].scriptAddress,
+            paycallAddress,
+            "script address[0] has been wrapped with paycall address"
+        );
+        assertEq(
+            result.quarkOperations[0].scriptCalldata,
+            abi.encodeWithSelector(
+                Paycall.run.selector,
+                cctpBridgeActionsAddress,
+                abi.encodeWithSelector(
+                    CCTPBridgeActions.bridgeUSDC.selector,
+                    address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155),
+                    2.1e6,
+                    6,
+                    bytes32(uint256(uint160(0xa11ce))),
+                    usdc_(1)
+                ),
+                0.5e6
+            ),
+            "calldata is Paycall.run(CCTPBridgeActions.bridgeUSDC(address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155), 2.1e6, 6, bytes32(uint256(uint160(0xa11ce))), usdc_(1))), 5e5);"
+        );
+        assertEq(
+            result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
+        );
+
+        // second operation
+        assertEq(
+            result.quarkOperations[1].scriptAddress,
+            paycallAddressBase,
+            "script address[1] has been wrapped with paycall address"
+        );
+        assertEq(
+            result.quarkOperations[1].scriptCalldata,
+            abi.encodeWithSelector(
+                Paycall.run.selector,
+                CodeJarHelper.getCodeAddress(type(CometSupplyActions).creationCode),
+                abi.encodeCall(CometSupplyActions.supply, (COMET, usdc_(8453), 5e6)),
+                0.1e6
+            ),
+            "calldata is Paycall.run(TransferActions.transferERC20Token(USDC_8453, address(0xceecee), 5e6), 1e5);"
+        );
+        assertEq(
+            result.quarkOperations[1].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
+        );
+
+        // Check the actions
+        assertEq(result.actions.length, 2, "two actions");
+        // first action
+        assertEq(result.actions[0].chainId, 1, "operation is on chainid 1");
+        assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
+        assertEq(result.actions[0].actionType, "BRIDGE", "action type is 'BRIDGE'");
+        assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
+        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC on mainnet");
+        assertEq(result.actions[0].paymentMaxCost, 0.5e6, "payment should have max cost of 5e5");
+        assertEq(
+            result.actions[0].actionContext,
+            abi.encode(
+                Actions.BridgeActionContext({
+                    amount: 2.1e6,
+                    price: 1e8,
+                    token: USDC_1,
+                    chainId: 1,
+                    recipient: address(0xa11ce),
+                    destinationChainId: 8453,
+                    bridgeType: Actions.BRIDGE_TYPE_CCTP
+                })
+            ),
+            "action context encoded from BridgeActionContext"
+        );
+        // second action
+        assertEq(result.actions[1].chainId, 8453, "operation is on chainid 8453");
+        assertEq(result.actions[1].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
+        assertEq(result.actions[1].actionType, "COMET_SUPPLY", "action type is 'COMET_SUPPLY'");
+        assertEq(result.actions[1].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
+        assertEq(result.actions[1].paymentToken, USDC_8453, "payment token is USDC on Base");
+        assertEq(result.actions[1].paymentMaxCost, 0.1e6, "payment should have max cost of 1e5");
+        assertEq(
+            result.actions[1].actionContext,
+            abi.encode(
+                Actions.CometSupplyActionContext({
+                    amount: 5e6,
+                    chainId: 8453,
+                    comet: COMET,
+                    price: 1e8,
+                    token: USDC_8453
+                })
+            ),
+            "action context encoded from CometSupplyActionContext"
+        );
+
+        // TODO: Check the contents of the EIP712 data
+        assertNotEq(result.eip712Data.digest, hex"", "non-empty digest");
+        assertNotEq(result.eip712Data.domainSeparator, hex"", "non-empty domain separator");
+        assertNotEq(result.eip712Data.hashStruct, hex"", "non-empty hashStruct");
+    }
+}

--- a/test/QuarkBuilderCometSupply.t.sol
+++ b/test/QuarkBuilderCometSupply.t.sol
@@ -114,10 +114,8 @@ contract QuarkBuilderCometSupplyTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
         assertEq(
             result.actions[0].actionContext,
-            abi.encode(
-                Actions.CometSupplyActionContext({amount: 2, chainId: 1, comet: COMET, price: 1e8, token: USDC_1})
-            ),
-            "action context encoded from CometSupplyActionContext"
+            abi.encode(Actions.SupplyActionContext({amount: 2, chainId: 1, comet: COMET, price: 1e8, token: USDC_1})),
+            "action context encoded from SupplyActionContext"
         );
 
         // TODO: Check the contents of the EIP712 data
@@ -175,10 +173,8 @@ contract QuarkBuilderCometSupplyTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].paymentMaxCost, 1e5, "payment max is set to 1e5 in this test case");
         assertEq(
             result.actions[0].actionContext,
-            abi.encode(
-                Actions.CometSupplyActionContext({amount: 2, chainId: 1, comet: COMET, price: 1e8, token: USDC_1})
-            ),
-            "action context encoded from CometSupplyActionContext"
+            abi.encode(Actions.SupplyActionContext({amount: 2, chainId: 1, comet: COMET, price: 1e8, token: USDC_1})),
+            "action context encoded from SupplyActionContext"
         );
 
         // TODO: Check the contents of the EIP712 data
@@ -304,15 +300,9 @@ contract QuarkBuilderCometSupplyTest is Test, QuarkBuilderTest {
         assertEq(
             result.actions[1].actionContext,
             abi.encode(
-                Actions.CometSupplyActionContext({
-                    amount: 5e6,
-                    chainId: 8453,
-                    comet: COMET,
-                    price: 1e8,
-                    token: USDC_8453
-                })
+                Actions.SupplyActionContext({amount: 5e6, chainId: 8453, comet: COMET, price: 1e8, token: USDC_8453})
             ),
-            "action context encoded from CometSupplyActionContext"
+            "action context encoded from SupplyActionContext"
         );
 
         // TODO: Check the contents of the EIP712 data
@@ -428,15 +418,9 @@ contract QuarkBuilderCometSupplyTest is Test, QuarkBuilderTest {
         assertEq(
             result.actions[1].actionContext,
             abi.encode(
-                Actions.CometSupplyActionContext({
-                    amount: 5e6,
-                    chainId: 8453,
-                    comet: COMET,
-                    price: 1e8,
-                    token: USDC_8453
-                })
+                Actions.SupplyActionContext({amount: 5e6, chainId: 8453, comet: COMET, price: 1e8, token: USDC_8453})
             ),
-            "action context encoded from CometSupplyActionContext"
+            "action context encoded from SupplyActionContext"
         );
 
         // TODO: Check the contents of the EIP712 data

--- a/test/QuarkBuilderTransfer.t.sol
+++ b/test/QuarkBuilderTransfer.t.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.23;
 import "forge-std/Test.sol";
 import "forge-std/console.sol";
 
+import "./lib/QuarkBuilderTest.sol";
+
 import {TransferActions} from "../src/DeFiScripts.sol";
 import {CCTPBridgeActions} from "../src/BridgeScripts.sol";
 
@@ -16,14 +18,8 @@ import {Quotecall} from "../src/Quotecall.sol";
 import {PaycallWrapper} from "../src/builder/PaycallWrapper.sol";
 import {PaymentInfo} from "../src/builder/PaymentInfo.sol";
 
-contract QuarkBuilderTest is Test {
+contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
     uint256 constant BLOCK_TIMESTAMP = 123_456_789;
-    address constant ETH_USD_PRICE_FEED_1 = 0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419;
-    address constant ETH_USD_PRICE_FEED_8453 = 0x71041dddad3595F9CEd3DcCFBe3D1F4b0a16Bb70;
-    address constant USDC_1 = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
-    address constant USDC_8453 = 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913;
-    // Random address for mock of USDC in random unsupported L2 chain
-    address constant USDC_7777 = 0x8D89c5CaA76592e30e0410B9e68C0f235c62B312;
 
     function testInsufficientFunds() public {
         QuarkBuilder builder = new QuarkBuilder();
@@ -143,7 +139,7 @@ contract QuarkBuilderTest is Test {
         );
 
         assertEq(result.version, "1.0.0", "version 1");
-        assertEq(result.paymentCurrency, "usdc", "usd currency");
+        assertEq(result.paymentCurrency, "usdc", "usdc currency");
 
         // Check the quark operations
         assertEq(result.quarkOperations.length, 1, "one operation");
@@ -274,7 +270,7 @@ contract QuarkBuilderTest is Test {
         );
 
         // Check the actions
-        assertEq(result.actions.length, 2, "one action");
+        assertEq(result.actions.length, 2, "two actions");
         assertEq(result.actions[0].chainId, 1, "operation is on chainid 1");
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "BRIDGE", "action type is 'BRIDGE'");
@@ -693,126 +689,5 @@ contract QuarkBuilderTest is Test {
             chainAccountsList_(6e6), // holding 6 USDC in total across chains 1, 8453
             paymentUsdc_(maxCosts)
         );
-    }
-
-    /**
-     *
-     * Fixture Functions
-     *
-     * @dev to avoid variable shadowing warnings and to provide a visual signifier when
-     * a function call is used to mock some data, we suffix all of our fixture-generating
-     * functions with a single underscore, like so: transferIntent_(...).
-     */
-    function transferUsdc_(uint256 chainId, uint256 amount, address recipient, uint256 blockTimestamp)
-        internal
-        pure
-        returns (QuarkBuilder.TransferIntent memory)
-    {
-        return QuarkBuilder.TransferIntent({
-            chainId: chainId,
-            sender: address(0xa11ce),
-            recipient: recipient,
-            amount: amount,
-            assetSymbol: "USDC",
-            blockTimestamp: blockTimestamp
-        });
-    }
-
-    function paymentUsdc_() internal pure returns (PaymentInfo.Payment memory) {
-        return paymentUsdc_(new PaymentInfo.PaymentMaxCost[](0));
-    }
-
-    function paymentUsdc_(PaymentInfo.PaymentMaxCost[] memory maxCosts)
-        internal
-        pure
-        returns (PaymentInfo.Payment memory)
-    {
-        return PaymentInfo.Payment({isToken: true, currency: "usdc", maxCosts: maxCosts});
-    }
-
-    function paymentUsd_() internal pure returns (PaymentInfo.Payment memory) {
-        return paymentUsd_(new PaymentInfo.PaymentMaxCost[](0));
-    }
-
-    function paymentUsd_(PaymentInfo.PaymentMaxCost[] memory maxCosts)
-        internal
-        pure
-        returns (PaymentInfo.Payment memory)
-    {
-        return PaymentInfo.Payment({isToken: false, currency: "usd", maxCosts: maxCosts});
-    }
-
-    function chainAccountsList_(uint256 amount) internal pure returns (Accounts.ChainAccounts[] memory) {
-        Accounts.ChainAccounts[] memory chainAccountsList = new Accounts.ChainAccounts[](2);
-        chainAccountsList[0] = Accounts.ChainAccounts({
-            chainId: 1,
-            quarkStates: quarkStates_(address(0xa11ce), 12),
-            assetPositionsList: assetPositionsList_(1, address(0xa11ce), uint256(amount / 2))
-        });
-        chainAccountsList[1] = Accounts.ChainAccounts({
-            chainId: 8453,
-            quarkStates: quarkStates_(address(0xb0b), 2),
-            assetPositionsList: assetPositionsList_(8453, address(0xb0b), uint256(amount / 2))
-        });
-        return chainAccountsList;
-    }
-
-    function quarkStates_() internal pure returns (Accounts.QuarkState[] memory) {
-        Accounts.QuarkState[] memory quarkStates = new Accounts.QuarkState[](1);
-        quarkStates[0] = quarkState_();
-        return quarkStates;
-    }
-
-    function maxCosts_(uint256 chainId, uint256 amount) internal pure returns (PaymentInfo.PaymentMaxCost[] memory) {
-        PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](1);
-        maxCosts[0] = PaymentInfo.PaymentMaxCost({chainId: chainId, amount: amount});
-        return maxCosts;
-    }
-
-    function assetPositionsList_(uint256 chainId, address account, uint256 balance)
-        internal
-        pure
-        returns (Accounts.AssetPositions[] memory)
-    {
-        Accounts.AssetPositions[] memory assetPositionsList = new Accounts.AssetPositions[](1);
-        assetPositionsList[0] = Accounts.AssetPositions({
-            asset: usdc_(chainId),
-            symbol: "USDC",
-            decimals: 6,
-            usdPrice: 1_0000_0000,
-            accountBalances: accountBalances_(account, balance)
-        });
-        return assetPositionsList;
-    }
-
-    function accountBalances_(address account, uint256 balance)
-        internal
-        pure
-        returns (Accounts.AccountBalance[] memory)
-    {
-        Accounts.AccountBalance[] memory accountBalances = new Accounts.AccountBalance[](1);
-        accountBalances[0] = Accounts.AccountBalance({account: account, balance: balance});
-        return accountBalances;
-    }
-
-    function usdc_(uint256 chainId) internal pure returns (address) {
-        if (chainId == 1) return USDC_1;
-        if (chainId == 8453) return USDC_8453;
-        if (chainId == 7777) return USDC_7777; // Mock with random L2's usdc
-        revert("no mock usdc for that chain id bye");
-    }
-
-    function quarkStates_(address account, uint96 nextNonce) internal pure returns (Accounts.QuarkState[] memory) {
-        Accounts.QuarkState[] memory quarkStates = new Accounts.QuarkState[](1);
-        quarkStates[0] = quarkState_(account, nextNonce);
-        return quarkStates;
-    }
-
-    function quarkState_() internal pure returns (Accounts.QuarkState memory) {
-        return quarkState_(address(0xa11ce), 3);
-    }
-
-    function quarkState_(address account, uint96 nextNonce) internal pure returns (Accounts.QuarkState memory) {
-        return Accounts.QuarkState({account: account, quarkNextNonce: nextNonce});
     }
 }

--- a/test/QuarkBuilderTransfer.t.sol
+++ b/test/QuarkBuilderTransfer.t.sol
@@ -21,6 +21,21 @@ import {PaymentInfo} from "../src/builder/PaymentInfo.sol";
 contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
     uint256 constant BLOCK_TIMESTAMP = 123_456_789;
 
+    function transferUsdc_(uint256 chainId, uint256 amount, address recipient, uint256 blockTimestamp)
+        internal
+        pure
+        returns (QuarkBuilder.TransferIntent memory)
+    {
+        return QuarkBuilder.TransferIntent({
+            chainId: chainId,
+            sender: address(0xa11ce),
+            recipient: recipient,
+            amount: amount,
+            assetSymbol: "USDC",
+            blockTimestamp: blockTimestamp
+        });
+    }
+
     function testInsufficientFunds() public {
         QuarkBuilder builder = new QuarkBuilder();
         vm.expectRevert(abi.encodeWithSelector(QuarkBuilder.InsufficientFunds.selector, 10e6, 0e6));

--- a/test/lib/QuarkBuilderTest.sol
+++ b/test/lib/QuarkBuilderTest.sol
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity ^0.8.23;
+
+import "forge-std/Test.sol";
+import "forge-std/console.sol";
+
+import {Accounts} from "../../src/builder/Accounts.sol";
+import {PaymentInfo} from "../../src/builder/PaymentInfo.sol";
+import {QuarkBuilder} from "../../src/builder/QuarkBuilder.sol";
+
+contract QuarkBuilderTest {
+    address constant USDC_1 = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+    address constant USDC_8453 = 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913;
+    // Random address for mock of USDC in random unsupported L2 chain
+    address constant USDC_7777 = 0x8D89c5CaA76592e30e0410B9e68C0f235c62B312;
+
+    address constant ETH_USD_PRICE_FEED_1 = 0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419;
+    address constant ETH_USD_PRICE_FEED_8453 = 0x71041dddad3595F9CEd3DcCFBe3D1F4b0a16Bb70;
+
+    /**
+     *
+     * Fixture Functions
+     *
+     * @dev to avoid variable shadowing warnings and to provide a visual signifier when
+     * a function call is used to mock some data, we suffix all of our fixture-generating
+     * functions with a single underscore, like so: transferIntent_(...).
+     */
+    function transferUsdc_(uint256 chainId, uint256 amount, address recipient, uint256 blockTimestamp)
+        internal
+        pure
+        returns (QuarkBuilder.TransferIntent memory)
+    {
+        return QuarkBuilder.TransferIntent({
+            chainId: chainId,
+            sender: address(0xa11ce),
+            recipient: recipient,
+            amount: amount,
+            assetSymbol: "USDC",
+            blockTimestamp: blockTimestamp
+        });
+    }
+
+    function paymentUsdc_() internal pure returns (PaymentInfo.Payment memory) {
+        return paymentUsdc_(new PaymentInfo.PaymentMaxCost[](0));
+    }
+
+    function paymentUsdc_(PaymentInfo.PaymentMaxCost[] memory maxCosts)
+        internal
+        pure
+        returns (PaymentInfo.Payment memory)
+    {
+        return PaymentInfo.Payment({isToken: true, currency: "usdc", maxCosts: maxCosts});
+    }
+
+    function paymentUsd_() internal pure returns (PaymentInfo.Payment memory) {
+        return paymentUsd_(new PaymentInfo.PaymentMaxCost[](0));
+    }
+
+    function paymentUsd_(PaymentInfo.PaymentMaxCost[] memory maxCosts)
+        internal
+        pure
+        returns (PaymentInfo.Payment memory)
+    {
+        return PaymentInfo.Payment({isToken: false, currency: "usd", maxCosts: maxCosts});
+    }
+
+    function chainAccountsList_(uint256 amount) internal pure returns (Accounts.ChainAccounts[] memory) {
+        Accounts.ChainAccounts[] memory chainAccountsList = new Accounts.ChainAccounts[](2);
+        chainAccountsList[0] = Accounts.ChainAccounts({
+            chainId: 1,
+            quarkStates: quarkStates_(address(0xa11ce), 12),
+            assetPositionsList: assetPositionsList_(1, address(0xa11ce), uint256(amount / 2))
+        });
+        chainAccountsList[1] = Accounts.ChainAccounts({
+            chainId: 8453,
+            quarkStates: quarkStates_(address(0xb0b), 2),
+            assetPositionsList: assetPositionsList_(8453, address(0xb0b), uint256(amount / 2))
+        });
+        return chainAccountsList;
+    }
+
+    function quarkStates_() internal pure returns (Accounts.QuarkState[] memory) {
+        Accounts.QuarkState[] memory quarkStates = new Accounts.QuarkState[](1);
+        quarkStates[0] = quarkState_();
+        return quarkStates;
+    }
+
+    function maxCosts_(uint256 chainId, uint256 amount) internal pure returns (PaymentInfo.PaymentMaxCost[] memory) {
+        PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](1);
+        maxCosts[0] = PaymentInfo.PaymentMaxCost({chainId: chainId, amount: amount});
+        return maxCosts;
+    }
+
+    function assetPositionsList_(uint256 chainId, address account, uint256 balance)
+        internal
+        pure
+        returns (Accounts.AssetPositions[] memory)
+    {
+        Accounts.AssetPositions[] memory assetPositionsList = new Accounts.AssetPositions[](1);
+        assetPositionsList[0] = Accounts.AssetPositions({
+            asset: usdc_(chainId),
+            symbol: "USDC",
+            decimals: 6,
+            usdPrice: 1_0000_0000,
+            accountBalances: accountBalances_(account, balance)
+        });
+        return assetPositionsList;
+    }
+
+    function accountBalances_(address account, uint256 balance)
+        internal
+        pure
+        returns (Accounts.AccountBalance[] memory)
+    {
+        Accounts.AccountBalance[] memory accountBalances = new Accounts.AccountBalance[](1);
+        accountBalances[0] = Accounts.AccountBalance({account: account, balance: balance});
+        return accountBalances;
+    }
+
+    function usdc_(uint256 chainId) internal pure returns (address) {
+        if (chainId == 1) return USDC_1;
+        if (chainId == 8453) return USDC_8453;
+        if (chainId == 7777) return USDC_7777; // Mock with random L2's usdc
+        revert("no mock usdc for that chain id bye");
+    }
+
+    function quarkStates_(address account, uint96 nextNonce) internal pure returns (Accounts.QuarkState[] memory) {
+        Accounts.QuarkState[] memory quarkStates = new Accounts.QuarkState[](1);
+        quarkStates[0] = quarkState_(account, nextNonce);
+        return quarkStates;
+    }
+
+    function quarkState_() internal pure returns (Accounts.QuarkState memory) {
+        return quarkState_(address(0xa11ce), 3);
+    }
+
+    function quarkState_(address account, uint96 nextNonce) internal pure returns (Accounts.QuarkState memory) {
+        return Accounts.QuarkState({account: account, quarkNextNonce: nextNonce});
+    }
+}

--- a/test/lib/QuarkBuilderTest.sol
+++ b/test/lib/QuarkBuilderTest.sol
@@ -25,21 +25,6 @@ contract QuarkBuilderTest {
      * a function call is used to mock some data, we suffix all of our fixture-generating
      * functions with a single underscore, like so: transferIntent_(...).
      */
-    function transferUsdc_(uint256 chainId, uint256 amount, address recipient, uint256 blockTimestamp)
-        internal
-        pure
-        returns (QuarkBuilder.TransferIntent memory)
-    {
-        return QuarkBuilder.TransferIntent({
-            chainId: chainId,
-            sender: address(0xa11ce),
-            recipient: recipient,
-            amount: amount,
-            assetSymbol: "USDC",
-            blockTimestamp: blockTimestamp
-        });
-    }
-
     function paymentUsdc_() internal pure returns (PaymentInfo.Payment memory) {
         return paymentUsdc_(new PaymentInfo.PaymentMaxCost[](0));
     }


### PR DESCRIPTION
~~Not quite done, but wanted to share in-progress version since I believe it's starting to become a blocker.~~

The CometSupply action is almost entirely adapted from the existing Tranfser action; I've tried to abstract shared functionality, but there are some places where it's somewhat awkward to share that functionality (specifically in the bridging logic).

For the test files, I've created a separate `QuarkBuilderTest` contract that our QuarkBuilder tests can inherit from. I moved the existing Transfer tests into QuarkBuilderTransfer.t.sol and wrote the new tests in QuarkBuilderCometSupply.t.sol.