### PR TITLE
Remove redundant `InsufficientFunds` check and properly account for amount needed on destination chain

### DIFF
--- a/test/builder/QuarkBuilderCometSupply.t.sol
+++ b/test/builder/QuarkBuilderCometSupply.t.sol
@@ -33,7 +33,7 @@ contract QuarkBuilderCometSupplyTest is Test, QuarkBuilderTest {
 
     function testInsufficientFunds() public {
         QuarkBuilder builder = new QuarkBuilder();
-        vm.expectRevert(abi.encodeWithSelector(QuarkBuilder.InsufficientFunds.selector, 2e6, 0e6));
+        vm.expectRevert(abi.encodeWithSelector(QuarkBuilder.FundsUnavailable.selector, "USDC", 2e6, 0e6));
         builder.cometSupply(
             cometSupply_(1, 2e6),
             chainAccountsList_(0e6), // but we are holding 0 USDC in total across 1, 8453
@@ -43,7 +43,8 @@ contract QuarkBuilderCometSupplyTest is Test, QuarkBuilderTest {
 
     function testMaxCostTooHigh() public {
         QuarkBuilder builder = new QuarkBuilder();
-        vm.expectRevert(QuarkBuilder.MaxCostTooHigh.selector);
+        // Max cost is too high, so total available funds is 0
+        vm.expectRevert(abi.encodeWithSelector(QuarkBuilder.FundsUnavailable.selector, "USDC", 1e6, 0e6));
         builder.cometSupply(
             cometSupply_(1, 1e6),
             chainAccountsList_(2e6), // holding 2 USDC in total across 1, 8453

--- a/test/builder/QuarkBuilderTransfer.t.sol
+++ b/test/builder/QuarkBuilderTransfer.t.sol
@@ -70,7 +70,7 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
 
     function testFundsOnUnbridgeableChains() public {
         QuarkBuilder builder = new QuarkBuilder();
-        // FundsUnavailable(2e6, 0e6, 2e6): Requested 2e6, Available 0e6
+        // FundsUnavailable("USDC", 2e6, 0e6): Requested 2e6, Available 0e6
         vm.expectRevert(abi.encodeWithSelector(QuarkBuilder.FundsUnavailable.selector, "USDC", 2e6, 0e6));
         builder.transfer(
             // there is no bridge to chain 7777, so we cannot get to our funds


### PR DESCRIPTION
We were not properly accounting for the payment token when checking if funds needed to be bridged. This only applies to the case where the payment token is also the action token. For example, if the user wants to transfer 10 USDC with a payment max cost of 1 USDC, the `needsBridgedFunds` needs to check that there is 11 USDC on the destination chain instead of just 10 USDC.

We also remove the `InsufficientFunds` check because it is redundant and seems like a subset of the `assertFundsAvailable` check. 