### PR TITLE
Support Matcha swaps in QuarkBuilder

### DIFF
--- a/src/DeFiScripts.sol
+++ b/src/DeFiScripts.sol
@@ -298,6 +298,7 @@ contract ApproveAndSwap {
      * @param sellToken The token address to approve
      * @param sellAmount The amount to approve
      * @param buyToken The token that is being bought
+     * @param expectedBuyAmount The expected amount of the buy token to receive after the swap
      * @param data The data to execute
      */
     function run(

--- a/src/builder/Actions.sol
+++ b/src/builder/Actions.sol
@@ -6,7 +6,7 @@ import {Strings} from "./Strings.sol";
 import {Accounts} from "./Accounts.sol";
 import {CodeJarHelper} from "./CodeJarHelper.sol";
 
-import {CometSupplyActions, TransferActions} from "../DeFiScripts.sol";
+import {ApproveAndSwap, CometSupplyActions, TransferActions} from "../DeFiScripts.sol";
 
 import {IQuarkWallet} from "quark-core/src/interfaces/IQuarkWallet.sol";
 import {PaycallWrapper} from "./PaycallWrapper.sol";
@@ -21,12 +21,11 @@ library Actions {
 
     string constant ACTION_TYPE_BORROW = "BORROW";
     string constant ACTION_TYPE_BRIDGE = "BRIDGE";
-    string constant ACTION_TYPE_BUY = "BUY";
     string constant ACTION_TYPE_CLAIM_REWARDS = "CLAIM_REWARDS";
     string constant ACTION_TYPE_DRIP_TOKENS = "DRIP_TOKENS";
     string constant ACTION_TYPE_REPAY = "REPAY";
-    string constant ACTION_TYPE_SELL = "SELL";
     string constant ACTION_TYPE_SUPPLY = "SUPPLY";
+    string constant ACTION_TYPE_SWAP = "SWAP";
     string constant ACTION_TYPE_TRANSFER = "TRANSFER";
     string constant ACTION_TYPE_WITHDRAW = "WITHDRAW";
     string constant ACTION_TYPE_WITHDRAW_AND_BORROW = "WITHDRAW_AND_BORROW";
@@ -37,6 +36,7 @@ library Actions {
     uint256 constant STANDARD_EXPIRY_BUFFER = 7 days;
 
     uint256 constant BRIDGE_EXPIRY_BUFFER = 7 days;
+    uint256 constant SWAP_EXPIRY_BUFFER = 3 days;
     uint256 constant TRANSFER_EXPIRY_BUFFER = 7 days;
 
     /* ===== Custom Errors ===== */
@@ -75,6 +75,21 @@ library Actions {
         address sender;
         uint256 destinationChainId;
         address recipient;
+        uint256 blockTimestamp;
+    }
+
+    struct MatchaSwap {
+        Accounts.ChainAccounts[] chainAccountsList;
+        address entryPoint;
+        bytes swapData;
+        address sellToken;
+        string sellTokenSymbol;
+        uint256 sellAmount;
+        address buyToken;
+        string buyTokenSymbol;
+        uint256 expectedBuyAmount;
+        uint256 chainId;
+        address sender;
         uint256 blockTimestamp;
     }
 
@@ -128,13 +143,6 @@ library Actions {
         address token;
     }
 
-    struct BuyActionContext {
-        uint256 amount;
-        uint256 chainId;
-        uint256 price;
-        address token;
-    }
-
     struct ClaimRewardsActionContext {
         uint256 amount;
         uint256 chainId;
@@ -157,13 +165,6 @@ library Actions {
         address token;
     }
 
-    struct SellActionContext {
-        uint256 amount;
-        uint256 chainId;
-        uint256 price;
-        address token;
-    }
-
     struct SupplyActionContext {
         uint256 amount;
         string assetSymbol;
@@ -171,6 +172,18 @@ library Actions {
         address comet;
         uint256 price;
         address token;
+    }
+
+    struct SwapActionContext {
+        uint256 chainId;
+        uint256 inputAmount;
+        address inputToken;
+        uint256 inputTokenPrice;
+        string inputTokenSymbol;
+        uint256 outputAmount;
+        address outputToken;
+        uint256 outputTokenPrice;
+        string outputTokenSymbol;
     }
 
     struct TransferActionContext {
@@ -541,6 +554,90 @@ library Actions {
         return (quarkOperation, action);
     }
 
+    function matchaSwap(MatchaSwap memory swap, PaymentInfo.Payment memory payment, bool useQuotecall)
+        internal
+        pure
+        returns (IQuarkWallet.QuarkOperation memory, Action memory)
+    {
+        bytes[] memory scriptSources = new bytes[](1);
+        scriptSources[0] = type(TransferActions).creationCode;
+
+        Accounts.ChainAccounts memory accounts = Accounts.findChainAccounts(swap.chainId, swap.chainAccountsList);
+
+        Accounts.AssetPositions memory sellTokenAssetPositions =
+            Accounts.findAssetPositions(swap.sellTokenSymbol, accounts.assetPositionsList);
+
+        Accounts.AssetPositions memory buyTokenAssetPositions =
+            Accounts.findAssetPositions(swap.buyTokenSymbol, accounts.assetPositionsList);
+
+        Accounts.QuarkState memory accountState = Accounts.findQuarkState(swap.sender, accounts.quarkStates);
+
+        // TODO: Handle wrapping ETH? Do we need to?
+        bytes memory scriptCalldata = abi.encodeWithSelector(
+            ApproveAndSwap.run.selector,
+            swap.entryPoint,
+            swap.sellToken,
+            swap.sellAmount,
+            swap.buyToken,
+            swap.expectedBuyAmount,
+            swap.swapData
+        );
+
+        // Construct QuarkOperation
+        IQuarkWallet.QuarkOperation memory quarkOperation = IQuarkWallet.QuarkOperation({
+            nonce: accountState.quarkNextNonce,
+            scriptAddress: CodeJarHelper.getCodeAddress(type(ApproveAndSwap).creationCode),
+            scriptCalldata: scriptCalldata,
+            scriptSources: scriptSources,
+            expiry: swap.blockTimestamp + SWAP_EXPIRY_BUFFER
+        });
+
+        if (payment.isToken) {
+            // Wrap operation with paycall
+            quarkOperation = useQuotecall
+                ? QuotecallWrapper.wrap(
+                    quarkOperation, swap.chainId, payment.currency, PaymentInfo.findMaxCost(payment, swap.chainId)
+                )
+                : PaycallWrapper.wrap(
+                    quarkOperation, swap.chainId, payment.currency, PaymentInfo.findMaxCost(payment, swap.chainId)
+                );
+        }
+
+        // Construct Action
+        SwapActionContext memory swapActionContext = SwapActionContext({
+            chainId: swap.chainId,
+            inputToken: swap.sellToken,
+            inputTokenPrice: sellTokenAssetPositions.usdPrice,
+            inputTokenSymbol: swap.sellTokenSymbol,
+            inputAmount: swap.sellAmount,
+            outputToken: swap.buyToken,
+            outputTokenPrice: buyTokenAssetPositions.usdPrice,
+            outputTokenSymbol: swap.buyTokenSymbol,
+            outputAmount: swap.expectedBuyAmount
+        });
+        string memory paymentMethod;
+        if (payment.isToken) {
+            // To pay with token, it has to be a paycall or quotecall.
+            paymentMethod = useQuotecall ? PAYMENT_METHOD_QUOTECALL : PAYMENT_METHOD_PAYCALL;
+        } else {
+            paymentMethod = PAYMENT_METHOD_OFFCHAIN;
+        }
+
+        Action memory action = Actions.Action({
+            chainId: swap.chainId,
+            quarkAccount: swap.sender,
+            actionType: ACTION_TYPE_SWAP,
+            actionContext: abi.encode(swapActionContext),
+            paymentMethod: paymentMethod,
+            // Null address for OFFCHAIN payment.
+            paymentToken: payment.isToken ? PaymentInfo.knownToken(payment.currency, swap.chainId).token : address(0),
+            paymentTokenSymbol: payment.currency,
+            paymentMaxCost: payment.isToken ? PaymentInfo.findMaxCost(payment, swap.chainId) : 0
+        });
+
+        return (quarkOperation, action);
+    }
+
     function findActionsOfType(Action[] memory actions, string memory actionType)
         internal
         pure
@@ -606,11 +703,6 @@ library Actions {
         return bs[0];
     }
 
-    function emptyBuyActionContext() external pure returns (BuyActionContext memory) {
-        BuyActionContext[] memory bs = new BuyActionContext[](1);
-        return bs[0];
-    }
-
     function emptyClaimRewardsActionContext() external pure returns (ClaimRewardsActionContext memory) {
         ClaimRewardsActionContext[] memory cs = new ClaimRewardsActionContext[](1);
         return cs[0];
@@ -626,13 +718,13 @@ library Actions {
         return rs[0];
     }
 
-    function emptySellActionContext() external pure returns (SellActionContext memory) {
-        SellActionContext[] memory ss = new SellActionContext[](1);
+    function emptySupplyActionContext() external pure returns (SupplyActionContext memory) {
+        SupplyActionContext[] memory ss = new SupplyActionContext[](1);
         return ss[0];
     }
 
-    function emptySupplyActionContext() external pure returns (SupplyActionContext memory) {
-        SupplyActionContext[] memory ss = new SupplyActionContext[](1);
+    function emptySwapActionContext() external pure returns (SwapActionContext memory) {
+        SwapActionContext[] memory ss = new SwapActionContext[](1);
         return ss[0];
     }
 

--- a/test/builder/QuarkBuilderSwap.t.sol
+++ b/test/builder/QuarkBuilderSwap.t.sol
@@ -1,0 +1,697 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity ^0.8.23;
+
+import "forge-std/Test.sol";
+import "forge-std/console.sol";
+
+import {QuarkBuilderTest} from "test/builder/lib/QuarkBuilderTest.sol";
+
+import {ApproveAndSwap} from "src/DeFiScripts.sol";
+import {CCTPBridgeActions} from "src/BridgeScripts.sol";
+
+import {Actions} from "src/builder/Actions.sol";
+import {Accounts} from "src/builder/Accounts.sol";
+import {CodeJarHelper} from "src/builder/CodeJarHelper.sol";
+import {QuarkBuilder} from "src/builder/QuarkBuilder.sol";
+import {Paycall} from "src/Paycall.sol";
+import {Quotecall} from "src/Quotecall.sol";
+import {PaycallWrapper} from "src/builder/PaycallWrapper.sol";
+import {PaymentInfo} from "src/builder/PaymentInfo.sol";
+
+contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
+    uint256 constant BLOCK_TIMESTAMP = 123_456_789;
+    address constant MATCHA_ENTRY_POINT = 0xDef1C0ded9bec7F1a1670819833240f027b25EfF;
+    bytes constant MATCHA_SWAP_DATA = hex"abcdef";
+
+    function buyWeth_(
+        uint256 chainId,
+        address sellToken,
+        uint256 sellAmount,
+        uint256 expectedBuyAmount,
+        address sender,
+        uint256 blockTimestamp
+    ) internal pure returns (QuarkBuilder.MatchaSwapIntent memory) {
+        address weth = weth_(chainId);
+        return matchaSwap_(
+            chainId,
+            MATCHA_ENTRY_POINT,
+            MATCHA_SWAP_DATA,
+            sellToken,
+            sellAmount,
+            weth,
+            expectedBuyAmount,
+            sender,
+            blockTimestamp
+        );
+    }
+
+    function matchaSwap_(
+        uint256 chainId,
+        address entryPoint,
+        bytes memory swapData,
+        address sellToken,
+        uint256 sellAmount,
+        address buyToken,
+        uint256 expectedBuyAmount,
+        address sender,
+        uint256 blockTimestamp
+    ) internal pure returns (QuarkBuilder.MatchaSwapIntent memory) {
+        return QuarkBuilder.MatchaSwapIntent({
+            chainId: chainId,
+            entryPoint: entryPoint,
+            swapData: swapData,
+            sellToken: sellToken,
+            sellAmount: sellAmount,
+            buyToken: buyToken,
+            expectedBuyAmount: expectedBuyAmount,
+            sender: sender,
+            blockTimestamp: blockTimestamp
+        });
+    }
+
+    function testInsufficientFunds() public {
+        QuarkBuilder builder = new QuarkBuilder();
+        vm.expectRevert(abi.encodeWithSelector(QuarkBuilder.FundsUnavailable.selector, "USDC", 3000e6, 0e6));
+        builder.swap(
+            buyWeth_(1, usdc_(1), 3000e6, 1e18, address(0xfe11a), BLOCK_TIMESTAMP), // swap 3000 USDC on chain 1 to 1 WETH
+            chainAccountsList_(0e6), // but we are holding 0 USDC in total across 1, 8453
+            paymentUsd_()
+        );
+    }
+
+    // TODO: This no longer tests for the MaxCostTooHigh, since it may be unreachable now. Verify that this is the case.
+    function testMaxCostTooHigh() public {
+        QuarkBuilder builder = new QuarkBuilder();
+        // Max cost is too high, so total available funds is 0
+        vm.expectRevert(abi.encodeWithSelector(QuarkBuilder.FundsUnavailable.selector, "USDC", 30e6, 0e6));
+        builder.swap(
+            buyWeth_(1, usdc_(1), 30e6, 0.01e18, address(0xfe11a), BLOCK_TIMESTAMP), // swap 30 USDC on chain 1 to 0.01 WETH
+            chainAccountsList_(60e6), // holding 60 USDC in total across chains 1, 8453
+            paymentUsdc_(maxCosts_(1, 1_000e6)) // but costs 1,000 USDC
+        );
+    }
+
+    function testFundsOnUnbridgeableChains() public {
+        QuarkBuilder builder = new QuarkBuilder();
+        // FundsUnavailable("USDC", 2e6, 0e6): Requested 2e6, Available 0e6
+        vm.expectRevert(abi.encodeWithSelector(QuarkBuilder.FundsUnavailable.selector, "USDC", 30e6, 0e6));
+        builder.swap(
+            // there is no bridge to chain 7777, so we cannot get to our funds
+            buyWeth_(7777, usdc_(7777), 30e6, 0.01e18, address(0xfe11a), BLOCK_TIMESTAMP), // swap 30 USDC on chain 1 to 0.01 WETH
+            chainAccountsList_(60e6), // holding 60 USDC in total across chains 1, 8453
+            paymentUsd_()
+        );
+    }
+
+    function testFundsUnavailableErrorGivesSuggestionForAvailableFunds() public {
+        QuarkBuilder builder = new QuarkBuilder();
+        // The 32e6 is the suggested amount (total available funds) to swap
+        vm.expectRevert(abi.encodeWithSelector(QuarkBuilder.FundsUnavailable.selector, "USDC", 30e6, 27e6));
+        builder.swap(
+            buyWeth_(1, usdc_(1), 30e6, 0.01e18, address(0xfe11a), BLOCK_TIMESTAMP), // swap 30 USDC on chain 1 to 0.01 WETH
+            chainAccountsList_(60e6), // holding 60 USDC in total across 1, 8453
+            paymentUsdc_(maxCosts_(1, 3e6)) // but costs 3 USDC
+        );
+    }
+
+    // TODO: Test selling WETH as well
+    function testLocalSwapSucceeds() public {
+        QuarkBuilder builder = new QuarkBuilder();
+        QuarkBuilder.BuilderResult memory result = builder.swap(
+            buyWeth_(1, usdc_(1), 3000e6, 1e18, address(0xa11ce), BLOCK_TIMESTAMP), // swap 3000 USDC on chain 1 to 1 WETH
+            chainAccountsList_(6000e6), // holding 6000 USDC in total across chains 1, 8453
+            paymentUsd_()
+        );
+
+        assertEq(result.version, "1.0.0", "version 1");
+        assertEq(result.paymentCurrency, "usd", "usd currency");
+
+        // Check the quark operations
+        assertEq(result.quarkOperations.length, 1, "one operation");
+        assertEq(
+            result.quarkOperations[0].scriptAddress,
+            address(
+                uint160(
+                    uint256(
+                        keccak256(
+                            abi.encodePacked(
+                                bytes1(0xff),
+                                /* codeJar address */
+                                address(CodeJarHelper.CODE_JAR_ADDRESS),
+                                uint256(0),
+                                /* script bytecode */
+                                keccak256(type(ApproveAndSwap).creationCode)
+                            )
+                        )
+                    )
+                )
+            ),
+            "script address is correct given the code jar address on mainnet"
+        );
+        assertEq(
+            result.quarkOperations[0].scriptCalldata,
+            abi.encodeCall(ApproveAndSwap.run, (MATCHA_ENTRY_POINT, USDC_1, 3000e6, WETH_1, 1e18, MATCHA_SWAP_DATA)),
+            "calldata is ApproveAndSwap.run(MATCHA_ENTRY_POINT, USDC_1, 3500e6, WETH_1, 1e18, MATCHA_SWAP_DATA);"
+        );
+        assertEq(
+            result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 3 days, "expiry is current blockTimestamp + 3 days"
+        );
+
+        // check the actions
+        assertEq(result.actions.length, 1, "one action");
+        assertEq(result.actions[0].chainId, 1, "operation is on chainid 1");
+        assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce does the swap");
+        assertEq(result.actions[0].actionType, "SWAP", "action type is 'SWAP'");
+        assertEq(result.actions[0].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
+        assertEq(result.actions[0].paymentToken, address(0), "payment token is null");
+        assertEq(result.actions[0].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
+        assertEq(
+            result.actions[0].actionContext,
+            abi.encode(
+                Actions.SwapActionContext({
+                    chainId: 1,
+                    inputToken: USDC_1,
+                    inputTokenPrice: 1e8,
+                    inputTokenSymbol: "USDC",
+                    inputAmount: 3000e6,
+                    outputToken: WETH_1,
+                    outputTokenPrice: 3000e8,
+                    outputTokenSymbol: "WETH",
+                    outputAmount: 1e18
+                })
+            ),
+            "action context encoded from SwapActionContext"
+        );
+
+        // TODO: Check the contents of the EIP712 data
+        assertNotEq(result.eip712Data.digest, hex"", "non-empty digest");
+        assertNotEq(result.eip712Data.domainSeparator, hex"", "non-empty domain separator");
+        assertNotEq(result.eip712Data.hashStruct, hex"", "non-empty hashStruct");
+    }
+
+    function testLocalSwapWithPaycallSucceeds() public {
+        QuarkBuilder builder = new QuarkBuilder();
+        PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](1);
+        maxCosts[0] = PaymentInfo.PaymentMaxCost({chainId: 1, amount: 5e6});
+        QuarkBuilder.BuilderResult memory result = builder.swap(
+            buyWeth_(1, usdc_(1), 3000e6, 1e18, address(0xa11ce), BLOCK_TIMESTAMP), // swap 3000 USDC on chain 1 to 1 WETH
+            chainAccountsList_(6010e6), // holding 6010 USDC in total across chains 1, 8453
+            paymentUsdc_(maxCosts)
+        );
+
+        address approveAndSwapAddress = CodeJarHelper.getCodeAddress(type(ApproveAndSwap).creationCode);
+        address paycallAddress = CodeJarHelper.getCodeAddress(
+            abi.encodePacked(type(Paycall).creationCode, abi.encode(ETH_USD_PRICE_FEED_1, USDC_1))
+        );
+
+        assertEq(result.version, "1.0.0", "version 1");
+        assertEq(result.paymentCurrency, "usdc", "usdc currency");
+
+        // Check the quark operations
+        assertEq(result.quarkOperations.length, 1, "one operation");
+        assertEq(
+            result.quarkOperations[0].scriptAddress,
+            paycallAddress,
+            "script address is correct given the code jar address on mainnet"
+        );
+        assertEq(
+            result.quarkOperations[0].scriptCalldata,
+            abi.encodeWithSelector(
+                Paycall.run.selector,
+                approveAndSwapAddress,
+                abi.encodeWithSelector(
+                    ApproveAndSwap.run.selector, MATCHA_ENTRY_POINT, USDC_1, 3000e6, WETH_1, 1e18, MATCHA_SWAP_DATA
+                ),
+                5e6
+            ),
+            "calldata is Paycall.run(ApproveAndSwap.run(MATCHA_ENTRY_POINT, USDC_1, 3500e6, WETH_1, 1e18, MATCHA_SWAP_DATA), 5e6);"
+        );
+        assertEq(
+            result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 3 days, "expiry is current blockTimestamp + 3 days"
+        );
+        // check the actions
+        assertEq(result.actions.length, 1, "one action");
+        assertEq(result.actions[0].chainId, 1, "operation is on chainid 1");
+        assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce does the swap");
+        assertEq(result.actions[0].actionType, "SWAP", "action type is 'SWAP'");
+        assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
+        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC");
+        assertEq(result.actions[0].paymentMaxCost, 5e6, "payment max is set to 5e6 in this test case");
+        assertEq(
+            result.actions[0].actionContext,
+            abi.encode(
+                Actions.SwapActionContext({
+                    chainId: 1,
+                    inputToken: USDC_1,
+                    inputTokenPrice: 1e8,
+                    inputTokenSymbol: "USDC",
+                    inputAmount: 3000e6,
+                    outputToken: WETH_1,
+                    outputTokenPrice: 3000e8,
+                    outputTokenSymbol: "WETH",
+                    outputAmount: 1e18
+                })
+            ),
+            "action context encoded from SwapActionContext"
+        );
+
+        // TODO: Check the contents of the EIP712 data
+        assertNotEq(result.eip712Data.digest, hex"", "non-empty digest");
+        assertNotEq(result.eip712Data.domainSeparator, hex"", "non-empty domain separator");
+        assertNotEq(result.eip712Data.hashStruct, hex"", "non-empty hashStruct");
+    }
+
+    function testBridgeSwapSucceeds() public {
+        QuarkBuilder builder = new QuarkBuilder();
+        QuarkBuilder.BuilderResult memory result = builder.swap(
+            buyWeth_(8453, usdc_(8453), 3000e6, 1e18, address(0xa11ce), BLOCK_TIMESTAMP), // swap 3000 USDC on chain 8453 to 1 WETH
+            chainAccountsList_(4000e6), // holding 4000 USDC in total across chains 1, 8453
+            paymentUsd_()
+        );
+
+        assertEq(result.version, "1.0.0", "version 1");
+        assertEq(result.paymentCurrency, "usd", "usd currency");
+
+        // Check the quark operations
+        assertEq(result.quarkOperations.length, 2, "two operations");
+        assertEq(
+            result.quarkOperations[0].scriptAddress,
+            address(
+                uint160(
+                    uint256(
+                        keccak256(
+                            abi.encodePacked(
+                                bytes1(0xff),
+                                /* codeJar address */
+                                address(CodeJarHelper.CODE_JAR_ADDRESS),
+                                uint256(0),
+                                /* script bytecode */
+                                keccak256(type(CCTPBridgeActions).creationCode)
+                            )
+                        )
+                    )
+                )
+            ),
+            "script address for bridge action is correct given the code jar address"
+        );
+        assertEq(
+            result.quarkOperations[0].scriptCalldata,
+            abi.encodeCall(
+                CCTPBridgeActions.bridgeUSDC,
+                (
+                    address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155),
+                    1000e6,
+                    6,
+                    bytes32(uint256(uint160(0xa11ce))),
+                    usdc_(1)
+                )
+            ),
+            "calldata is CCTPBridgeActions.bridgeUSDC(address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155), 2e6, 6, bytes32(uint256(uint160(0xa11ce))), usdc_(1)));"
+        );
+        assertEq(
+            result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
+        );
+        assertEq(
+            result.quarkOperations[1].scriptAddress,
+            address(
+                uint160(
+                    uint256(
+                        keccak256(
+                            abi.encodePacked(
+                                bytes1(0xff),
+                                /* codeJar address */
+                                address(CodeJarHelper.CODE_JAR_ADDRESS),
+                                uint256(0),
+                                /* script bytecode */
+                                keccak256(type(ApproveAndSwap).creationCode)
+                            )
+                        )
+                    )
+                )
+            ),
+            "script address for transfer is correct given the code jar address"
+        );
+        assertEq(
+            result.quarkOperations[1].scriptCalldata,
+            abi.encodeCall(
+                ApproveAndSwap.run, (MATCHA_ENTRY_POINT, USDC_8453, 3000e6, WETH_8453, 1e18, MATCHA_SWAP_DATA)
+            ),
+            "calldata is ApproveAndSwap.run(MATCHA_ENTRY_POINT, USDC_8453, 3500e6, WETH_8453, 1e18, MATCHA_SWAP_DATA);"
+        );
+        assertEq(
+            result.quarkOperations[1].expiry, BLOCK_TIMESTAMP + 3 days, "expiry is current blockTimestamp + 3 days"
+        );
+
+        // Check the actions
+        assertEq(result.actions.length, 2, "two actions");
+        assertEq(result.actions[0].chainId, 1, "operation is on chainid 1");
+        assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
+        assertEq(result.actions[0].actionType, "BRIDGE", "action type is 'BRIDGE'");
+        assertEq(result.actions[0].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
+        assertEq(result.actions[0].paymentToken, address(0), "payment token is null");
+        assertEq(result.actions[0].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
+        assertEq(
+            result.actions[0].actionContext,
+            abi.encode(
+                Actions.BridgeActionContext({
+                    amount: 1000e6,
+                    price: 1e8,
+                    token: USDC_1,
+                    assetSymbol: "USDC",
+                    chainId: 1,
+                    recipient: address(0xa11ce),
+                    destinationChainId: 8453,
+                    bridgeType: Actions.BRIDGE_TYPE_CCTP
+                })
+            ),
+            "action context encoded from BridgeActionContext"
+        );
+        assertEq(result.actions[1].chainId, 8453, "operation is on chainid 8453");
+        assertEq(result.actions[1].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
+        assertEq(result.actions[1].actionType, "SWAP", "action type is 'SWAP'");
+        assertEq(result.actions[1].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
+        assertEq(result.actions[1].paymentToken, address(0), "payment token is null");
+        assertEq(result.actions[1].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
+        assertEq(
+            result.actions[1].actionContext,
+            abi.encode(
+                Actions.SwapActionContext({
+                    chainId: 8453,
+                    inputToken: USDC_8453,
+                    inputTokenPrice: 1e8,
+                    inputTokenSymbol: "USDC",
+                    inputAmount: 3000e6,
+                    outputToken: WETH_8453,
+                    outputTokenPrice: 3000e8,
+                    outputTokenSymbol: "WETH",
+                    outputAmount: 1e18
+                })
+            ),
+            "action context encoded from SwapActionContext"
+        );
+
+        // TODO: Check the contents of the EIP712 data
+        assertNotEq(result.eip712Data.digest, hex"", "non-empty digest");
+        assertNotEq(result.eip712Data.domainSeparator, hex"", "non-empty domain separator");
+        assertNotEq(result.eip712Data.hashStruct, hex"", "non-empty hashStruct");
+    }
+
+    function testBridgeSwapWithPaycallSucceeds() public {
+        QuarkBuilder builder = new QuarkBuilder();
+        PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](2);
+        maxCosts[0] = PaymentInfo.PaymentMaxCost({chainId: 1, amount: 5e6});
+        maxCosts[1] = PaymentInfo.PaymentMaxCost({chainId: 8453, amount: 1e6});
+        // Note: There are 2000e6 USDC on each chain, so the Builder should attempt to bridge 1000 + 1 (for payment) USDC to chain 8453
+        QuarkBuilder.BuilderResult memory result = builder.swap(
+            buyWeth_(8453, usdc_(8453), 3000e6, 1e18, address(0xa11ce), BLOCK_TIMESTAMP), // swap 3000 USDC on chain 8453 to 1 WETH
+            chainAccountsList_(4000e6), // holding 4000 USDC in total across chains 1, 8453
+            paymentUsdc_(maxCosts)
+        );
+
+        address approveAndSwapAddress = CodeJarHelper.getCodeAddress(type(ApproveAndSwap).creationCode);
+        address paycallAddress = CodeJarHelper.getCodeAddress(
+            abi.encodePacked(type(Paycall).creationCode, abi.encode(ETH_USD_PRICE_FEED_1, USDC_1))
+        );
+        address paycallAddressBase = CodeJarHelper.getCodeAddress(
+            abi.encodePacked(type(Paycall).creationCode, abi.encode(ETH_USD_PRICE_FEED_8453, USDC_8453))
+        );
+        address cctpBridgeActionsAddress = CodeJarHelper.getCodeAddress(type(CCTPBridgeActions).creationCode);
+
+        assertEq(result.version, "1.0.0", "version 1");
+        assertEq(result.paymentCurrency, "usdc", "usdc currency");
+
+        // Check the quark operations
+        assertEq(result.quarkOperations.length, 2, "two operations");
+        assertEq(
+            result.quarkOperations[0].scriptAddress,
+            paycallAddress,
+            "script address[0] has been wrapped with paycall address"
+        );
+        assertEq(
+            result.quarkOperations[0].scriptCalldata,
+            abi.encodeWithSelector(
+                Paycall.run.selector,
+                cctpBridgeActionsAddress,
+                abi.encodeWithSelector(
+                    CCTPBridgeActions.bridgeUSDC.selector,
+                    address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155),
+                    1001e6,
+                    6,
+                    bytes32(uint256(uint160(0xa11ce))),
+                    usdc_(1)
+                ),
+                5e6
+            ),
+            "calldata is Paycall.run(CCTPBridgeActions.bridgeUSDC(address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155), 2.1e6, 6, bytes32(uint256(uint160(0xa11ce))), usdc_(1))), 5e5);"
+        );
+        assertEq(
+            result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
+        );
+        assertEq(
+            result.quarkOperations[1].scriptAddress,
+            paycallAddressBase,
+            "script address[1] has been wrapped with paycall address"
+        );
+        assertEq(
+            result.quarkOperations[1].scriptCalldata,
+            abi.encodeWithSelector(
+                Paycall.run.selector,
+                approveAndSwapAddress,
+                abi.encodeWithSelector(
+                    ApproveAndSwap.run.selector,
+                    MATCHA_ENTRY_POINT,
+                    USDC_8453,
+                    3000e6,
+                    WETH_8453,
+                    1e18,
+                    MATCHA_SWAP_DATA
+                ),
+                1e6
+            ),
+            "calldata is Paycall.run(ApproveAndSwap.run(MATCHA_ENTRY_POINT, USDC_8453, 3500e6, WETH_8453, 1e18, MATCHA_SWAP_DATA), 5e6);"
+        );
+        assertEq(
+            result.quarkOperations[1].expiry, BLOCK_TIMESTAMP + 3 days, "expiry is current blockTimestamp + 3 days"
+        );
+
+        // Check the actions
+        assertEq(result.actions.length, 2, "one action");
+        assertEq(result.actions[0].chainId, 1, "operation is on chainid 1");
+        assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
+        assertEq(result.actions[0].actionType, "BRIDGE", "action type is 'BRIDGE'");
+        assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
+        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC on mainnet");
+        assertEq(result.actions[0].paymentMaxCost, 5e6, "payment should have max cost of 5e6");
+        assertEq(
+            result.actions[0].actionContext,
+            abi.encode(
+                Actions.BridgeActionContext({
+                    amount: 1001e6,
+                    price: 1e8,
+                    token: USDC_1,
+                    assetSymbol: "USDC",
+                    chainId: 1,
+                    recipient: address(0xa11ce),
+                    destinationChainId: 8453,
+                    bridgeType: Actions.BRIDGE_TYPE_CCTP
+                })
+            ),
+            "action context encoded from BridgeActionContext"
+        );
+        assertEq(result.actions[1].chainId, 8453, "operation is on chainid 8453");
+        assertEq(result.actions[1].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
+        assertEq(result.actions[1].actionType, "SWAP", "action type is 'SWAP'");
+        assertEq(result.actions[1].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
+        assertEq(result.actions[1].paymentToken, USDC_8453, "payment token is USDC on Base");
+        assertEq(result.actions[1].paymentMaxCost, 1e6, "payment should have max cost of 1e6");
+        assertEq(
+            result.actions[1].actionContext,
+            abi.encode(
+                Actions.SwapActionContext({
+                    chainId: 8453,
+                    inputToken: USDC_8453,
+                    inputTokenPrice: 1e8,
+                    inputTokenSymbol: "USDC",
+                    inputAmount: 3000e6,
+                    outputToken: WETH_8453,
+                    outputTokenPrice: 3000e8,
+                    outputTokenSymbol: "WETH",
+                    outputAmount: 1e18
+                })
+            ),
+            "action context encoded from SwapActionContext"
+        );
+
+        // TODO: Check the contents of the EIP712 data
+        assertNotEq(result.eip712Data.digest, hex"", "non-empty digest");
+        assertNotEq(result.eip712Data.domainSeparator, hex"", "non-empty domain separator");
+        assertNotEq(result.eip712Data.hashStruct, hex"", "non-empty hashStruct");
+    }
+
+    function testBridgeSwapBridgesPaymentToken() public {
+        QuarkBuilder builder = new QuarkBuilder();
+        PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](2);
+        maxCosts[0] = PaymentInfo.PaymentMaxCost({chainId: 1, amount: 5e6});
+        maxCosts[1] = PaymentInfo.PaymentMaxCost({chainId: 8453, amount: 3500e6});
+        // Note: There are 3000e6 USDC on each chain, so the Builder should attempt to bridge 500 USDC to chain 8453 to cover the max cost
+        QuarkBuilder.BuilderResult memory result = builder.swap(
+            buyWeth_(8453, usdt_(8453), 3000e6, 1e18, address(0xa11ce), BLOCK_TIMESTAMP), // swap 3000 USDT on chain 8453 to 1 WETH
+            chainAccountsList_(6000e6), // holding 6000 USDC and USDT in total across chains 1, 8453
+            paymentUsdc_(maxCosts)
+        );
+
+        address approveAndSwapAddress = CodeJarHelper.getCodeAddress(type(ApproveAndSwap).creationCode);
+        address paycallAddress = CodeJarHelper.getCodeAddress(
+            abi.encodePacked(type(Paycall).creationCode, abi.encode(ETH_USD_PRICE_FEED_1, USDC_1))
+        );
+        address paycallAddressBase = CodeJarHelper.getCodeAddress(
+            abi.encodePacked(type(Paycall).creationCode, abi.encode(ETH_USD_PRICE_FEED_8453, USDC_8453))
+        );
+        address cctpBridgeActionsAddress = CodeJarHelper.getCodeAddress(type(CCTPBridgeActions).creationCode);
+
+        assertEq(result.version, "1.0.0", "version 1");
+        assertEq(result.paymentCurrency, "usdc", "usdc currency");
+
+        // Check the quark operations
+        assertEq(result.quarkOperations.length, 2, "two operations");
+        assertEq(
+            result.quarkOperations[0].scriptAddress,
+            paycallAddress,
+            "script address[0] has been wrapped with paycall address"
+        );
+        assertEq(
+            result.quarkOperations[0].scriptCalldata,
+            abi.encodeWithSelector(
+                Paycall.run.selector,
+                cctpBridgeActionsAddress,
+                abi.encodeWithSelector(
+                    CCTPBridgeActions.bridgeUSDC.selector,
+                    address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155),
+                    500e6,
+                    6,
+                    bytes32(uint256(uint160(0xa11ce))),
+                    usdc_(1)
+                ),
+                5e6
+            ),
+            "calldata is Paycall.run(CCTPBridgeActions.bridgeUSDC(address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155), 500e6, 6, bytes32(uint256(uint160(0xa11ce))), usdc_(1))), 5e6);"
+        );
+        assertEq(
+            result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
+        );
+        assertEq(
+            result.quarkOperations[1].scriptCalldata,
+            abi.encodeWithSelector(
+                Paycall.run.selector,
+                approveAndSwapAddress,
+                abi.encodeWithSelector(
+                    ApproveAndSwap.run.selector,
+                    MATCHA_ENTRY_POINT,
+                    USDT_8453,
+                    3000e6,
+                    WETH_8453,
+                    1e18,
+                    MATCHA_SWAP_DATA
+                ),
+                3500e6
+            ),
+            "calldata is Paycall.run(ApproveAndSwap.run(MATCHA_ENTRY_POINT, USDT_8453, 3500e6, WETH_8453, 1e18, MATCHA_SWAP_DATA), 3500e6);"
+        );
+        assertEq(
+            result.quarkOperations[1].scriptAddress,
+            paycallAddressBase,
+            "script address[1] has been wrapped with paycall address"
+        );
+        assertEq(
+            result.quarkOperations[1].expiry, BLOCK_TIMESTAMP + 3 days, "expiry is current blockTimestamp + 3 days"
+        );
+
+        // Check the actions
+        assertEq(result.actions.length, 2, "one action");
+        assertEq(result.actions[0].chainId, 1, "operation is on chainid 1");
+        assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
+        assertEq(result.actions[0].actionType, "BRIDGE", "action type is 'BRIDGE'");
+        assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
+        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC on mainnet");
+        assertEq(result.actions[0].paymentMaxCost, 5e6, "payment should have max cost of 5e6");
+        assertEq(
+            result.actions[0].actionContext,
+            abi.encode(
+                Actions.BridgeActionContext({
+                    amount: 500e6,
+                    price: 1e8,
+                    token: USDC_1,
+                    assetSymbol: "USDC",
+                    chainId: 1,
+                    recipient: address(0xa11ce),
+                    destinationChainId: 8453,
+                    bridgeType: Actions.BRIDGE_TYPE_CCTP
+                })
+            ),
+            "action context encoded from BridgeActionContext"
+        );
+        assertEq(result.actions[1].chainId, 8453, "operation is on chainid 8453");
+        assertEq(result.actions[1].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
+        assertEq(result.actions[1].actionType, "SWAP", "action type is 'SWAP'");
+        assertEq(result.actions[1].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
+        assertEq(result.actions[1].paymentToken, USDC_8453, "payment token is USDC on Base");
+        assertEq(result.actions[1].paymentMaxCost, 3500e6, "payment should have max cost of 3500e6");
+        assertEq(
+            result.actions[1].actionContext,
+            abi.encode(
+                Actions.SwapActionContext({
+                    chainId: 8453,
+                    inputToken: USDT_8453,
+                    inputTokenPrice: 1e8,
+                    inputTokenSymbol: "USDT",
+                    inputAmount: 3000e6,
+                    outputToken: WETH_8453,
+                    outputTokenPrice: 3000e8,
+                    outputTokenSymbol: "WETH",
+                    outputAmount: 1e18
+                })
+            ),
+            "action context encoded from SwapActionContext"
+        );
+        // TODO: Check the contents of the EIP712 data
+        assertNotEq(result.eip712Data.digest, hex"", "non-empty digest");
+        assertNotEq(result.eip712Data.domainSeparator, hex"", "non-empty domain separator");
+        assertNotEq(result.eip712Data.hashStruct, hex"", "non-empty hashStruct");
+    }
+
+    function testIgnoresChainIfMaxCostIsNotSpecified() public {
+        QuarkBuilder builder = new QuarkBuilder();
+        PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](1);
+        maxCosts[0] = PaymentInfo.PaymentMaxCost({chainId: 8453, amount: 1e6});
+
+        // Note: There are 2000e6 USDC on each chain, so the Builder should attempt to bridge 1001 USDC to chain 8453.
+        // The extra 1 USDC is to cover the payment max cost on chain 8453.
+        // However, max cost is not specified for chain 1, so the Builder will ignore the chain and revert because
+        // there will be insufficient funds for the transfer.
+
+        // The `FundsAvailable` error tells us that 3000 USDC was asked to be swap, but only 1999 USDC was available.
+        // (1999 USDC instead of 2000 USDC because 1 USDC is reserved for the payment max cost)
+        vm.expectRevert(abi.encodeWithSelector(QuarkBuilder.FundsUnavailable.selector, "USDC", 3000e6, 1999e6));
+        builder.swap(
+            buyWeth_(8453, usdc_(8453), 3000e6, 1e18, address(0xfe11a), BLOCK_TIMESTAMP), // swap 3000 USDC on chain 8453 to 1 WETH
+            chainAccountsList_(4000e6), // holding 4000 USDC in total across chains 1, 8453
+            paymentUsdc_(maxCosts)
+        );
+    }
+
+    function testRevertsIfNotEnoughFundsToBridge() public {
+        QuarkBuilder builder = new QuarkBuilder();
+        PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](2);
+        maxCosts[0] = PaymentInfo.PaymentMaxCost({chainId: 1, amount: 3000e6});
+        maxCosts[1] = PaymentInfo.PaymentMaxCost({chainId: 8453, amount: 3001e6});
+
+        // Note: Need to bridge 1 USDC to cover max cost on chain 8453, but there is 0 available to bridge from chain 1 because they
+        // are all reserved for the max cost on chain 1.
+        vm.expectRevert(abi.encodeWithSelector(Actions.NotEnoughFundsToBridge.selector, "usdc", 1e6, 1e6));
+        builder.swap(
+            buyWeth_(8453, usdt_(8453), 3000e6, 1e18, address(0xa11ce), BLOCK_TIMESTAMP), // swap 3000 USDT on chain 8453 to 1 WETH
+            chainAccountsList_(6000e6), // holding 6000 USDT in total across chains 1, 8453
+            paymentUsdc_(maxCosts)
+        );
+    }
+}

--- a/test/builder/QuarkBuilderTransfer.t.sol
+++ b/test/builder/QuarkBuilderTransfer.t.sol
@@ -85,7 +85,7 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         // The 97e6 is the suggested amount (total available funds) to transfer
         vm.expectRevert(abi.encodeWithSelector(QuarkBuilder.FundsUnavailable.selector, "USDC", 100e6, 97e6));
         builder.transfer(
-            transferUsdc_(1, 100e6, address(0xfe11a), BLOCK_TIMESTAMP), // transfer 1 USDC on chain 1 to 0xfe11a
+            transferUsdc_(1, 100e6, address(0xfe11a), BLOCK_TIMESTAMP), // transfer 100 USDC on chain 1 to 0xfe11a
             chainAccountsList_(200e6), // holding 200 USDC in total across 1, 8453
             paymentUsdc_(maxCosts_(1, 3e6)) // but costs 3 USDC
         );

--- a/test/builder/lib/QuarkBuilderTest.sol
+++ b/test/builder/lib/QuarkBuilderTest.sol
@@ -13,9 +13,12 @@ contract QuarkBuilderTest {
     address constant USDC_8453 = 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913;
     address constant USDT_1 = 0xdAC17F958D2ee523a2206206994597C13D831ec7;
     address constant USDT_8453 = 0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2;
+    address constant WETH_1 = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+    address constant WETH_8453 = 0x4200000000000000000000000000000000000006;
     // Random address for mock assets in random unsupported chain
     address constant USDC_7777 = 0x8D89c5CaA76592e30e0410B9e68C0f235c62B312;
     address constant USDT_7777 = address(0xDEADBEEF);
+    address constant WETH_7777 = address(0xDEEDBEEF);
 
     address constant ETH_USD_PRICE_FEED_1 = 0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419;
     address constant ETH_USD_PRICE_FEED_8453 = 0x71041dddad3595F9CEd3DcCFBe3D1F4b0a16Bb70;
@@ -52,8 +55,9 @@ contract QuarkBuilderTest {
         return PaymentInfo.Payment({isToken: false, currency: "usd", maxCosts: maxCosts});
     }
 
+    // TODO: refactor
     function chainAccountsList_(uint256 amount) internal pure returns (Accounts.ChainAccounts[] memory) {
-        Accounts.ChainAccounts[] memory chainAccountsList = new Accounts.ChainAccounts[](2);
+        Accounts.ChainAccounts[] memory chainAccountsList = new Accounts.ChainAccounts[](3);
         chainAccountsList[0] = Accounts.ChainAccounts({
             chainId: 1,
             quarkStates: quarkStates_(address(0xa11ce), 12),
@@ -63,6 +67,11 @@ contract QuarkBuilderTest {
             chainId: 8453,
             quarkStates: quarkStates_(address(0xb0b), 2),
             assetPositionsList: assetPositionsList_(8453, address(0xb0b), uint256(amount / 2))
+        });
+        chainAccountsList[2] = Accounts.ChainAccounts({
+            chainId: 7777,
+            quarkStates: quarkStates_(address(0xc0b), 5),
+            assetPositionsList: assetPositionsList_(7777, address(0xc0b), uint256(0))
         });
         return chainAccountsList;
     }
@@ -84,7 +93,7 @@ contract QuarkBuilderTest {
         pure
         returns (Accounts.AssetPositions[] memory)
     {
-        Accounts.AssetPositions[] memory assetPositionsList = new Accounts.AssetPositions[](2);
+        Accounts.AssetPositions[] memory assetPositionsList = new Accounts.AssetPositions[](3);
         assetPositionsList[0] = Accounts.AssetPositions({
             asset: usdc_(chainId),
             symbol: "USDC",
@@ -98,6 +107,13 @@ contract QuarkBuilderTest {
             decimals: 6,
             usdPrice: 1_0000_0000,
             accountBalances: accountBalances_(account, balance)
+        });
+        assetPositionsList[2] = Accounts.AssetPositions({
+            asset: weth_(chainId),
+            symbol: "WETH",
+            decimals: 18,
+            usdPrice: 3000_0000_0000,
+            accountBalances: accountBalances_(account, 0)
         });
         return assetPositionsList;
     }
@@ -124,6 +140,13 @@ contract QuarkBuilderTest {
         if (chainId == 8453) return USDT_8453;
         if (chainId == 7777) return USDT_7777; // Mock with random chain's USDT
         revert("no mock usdt for that chain id bye");
+    }
+
+    function weth_(uint256 chainId) internal pure returns (address) {
+        if (chainId == 1) return WETH_1;
+        if (chainId == 8453) return WETH_8453;
+        if (chainId == 7777) return WETH_7777; // Mock with random chain's WETH
+        revert("no mock weth for that chain id bye");
     }
 
     function quarkStates_(address account, uint96 nextNonce) internal pure returns (Accounts.QuarkState[] memory) {


### PR DESCRIPTION
This PR adds support for Matcha swaps in the QuarkBuilder. I also changed the action context for swaps from two separate `Buy` and `Sell` action contexts to one single `Swap` action context.