### PR TITLE
Auto wrap/unwrap

### DIFF
--- a/src/WrapperScripts.sol
+++ b/src/WrapperScripts.sol
@@ -19,7 +19,7 @@ contract WrapperActions {
         IWstETH(wrapper).wrap(amount);
     }
 
-    function unwrapLidoWstETH(address wrapper, uint256 amount) external {
+    function unwrapLidoWstETH(address wstETH, uint256 amount) external {
         IWstETH(wrapper).unwrap(amount);
     }
 }

--- a/src/WrapperScripts.sol
+++ b/src/WrapperScripts.sol
@@ -10,7 +10,7 @@ contract WrapperActions {
         IWETH(wrapper).deposit{value: amount}();
     }
 
-    function unwrapWETH(address wrapper, uint256 amount) external {
+    function unwrapWETH(address weth, uint256 amount) external {
         IWETH(wrapper).withdraw(amount);
     }
 

--- a/src/WrapperScripts.sol
+++ b/src/WrapperScripts.sol
@@ -6,7 +6,7 @@ import {IWETH} from "./interfaces/IWETH.sol";
 import {IWstETH} from "./interfaces/IWstETH.sol";
 
 contract WrapperActions {
-    function wrapETH(address wrapper, uint256 amount) external payable {
+    function wrapETH(address weth, uint256 amount) external payable {
         IWETH(wrapper).deposit{value: amount}();
     }
 

--- a/src/WrapperScripts.sol
+++ b/src/WrapperScripts.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity 0.8.23;
+
+import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
+import {IWETH} from "./interfaces/IWETH.sol";
+import {IWstETH} from "./interfaces/IWstETH.sol";
+
+contract IWETHActions {
+    function wrapETH(address wrapper, uint256 amount) external payable {
+        IWETH(wrapper).deposit{value: amount}();
+    }
+
+    function unwrapWETH(address wrapper, uint256 amount) external {
+        IWETH(wrapper).withdraw(amount);
+    }
+}
+
+contract IWstETHActions {
+    function wrapLidoStETH(address wrapper, address tokenToWrap, uint256 amount) external {
+        IERC20(tokenToWrap).approve(wrapper, amount);
+        IWstETH(wrapper).wrap(amount);
+    }
+
+    function unwrapLidoWstETH(address wrapper, address tokenToUnwrap, uint256 amount) external {
+        IERC20(tokenToUnwrap).approve(wrapper, amount);
+        IWstETH(wrapper).unwrap(amount);
+    }
+}

--- a/src/WrapperScripts.sol
+++ b/src/WrapperScripts.sol
@@ -7,19 +7,19 @@ import {IWstETH} from "./interfaces/IWstETH.sol";
 
 contract WrapperActions {
     function wrapETH(address weth, uint256 amount) external payable {
-        IWETH(wrapper).deposit{value: amount}();
+        IWETH(weth).deposit{value: amount}();
     }
 
     function unwrapWETH(address weth, uint256 amount) external {
-        IWETH(wrapper).withdraw(amount);
+        IWETH(weth).withdraw(amount);
     }
 
     function wrapLidoStETH(address wstETH, address stETH, uint256 amount) external {
-        IERC20(tokenToWrap).approve(wrapper, amount);
-        IWstETH(wrapper).wrap(amount);
+        IERC20(stETH).approve(wstETH, amount);
+        IWstETH(wstETH).wrap(amount);
     }
 
     function unwrapLidoWstETH(address wstETH, uint256 amount) external {
-        IWstETH(wrapper).unwrap(amount);
+        IWstETH(wstETH).unwrap(amount);
     }
 }

--- a/src/WrapperScripts.sol
+++ b/src/WrapperScripts.sol
@@ -5,7 +5,7 @@ import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
 import {IWETH} from "./interfaces/IWETH.sol";
 import {IWstETH} from "./interfaces/IWstETH.sol";
 
-contract IWETHActions {
+contract WrapperActions {
     function wrapETH(address wrapper, uint256 amount) external payable {
         IWETH(wrapper).deposit{value: amount}();
     }
@@ -13,9 +13,7 @@ contract IWETHActions {
     function unwrapWETH(address wrapper, uint256 amount) external {
         IWETH(wrapper).withdraw(amount);
     }
-}
 
-contract IWstETHActions {
     function wrapLidoStETH(address wrapper, address tokenToWrap, uint256 amount) external {
         IERC20(tokenToWrap).approve(wrapper, amount);
         IWstETH(wrapper).wrap(amount);

--- a/src/WrapperScripts.sol
+++ b/src/WrapperScripts.sol
@@ -14,7 +14,7 @@ contract WrapperActions {
         IWETH(wrapper).withdraw(amount);
     }
 
-    function wrapLidoStETH(address wrapper, address tokenToWrap, uint256 amount) external {
+    function wrapLidoStETH(address wstETH, address stETH, uint256 amount) external {
         IERC20(tokenToWrap).approve(wrapper, amount);
         IWstETH(wrapper).wrap(amount);
     }

--- a/src/WrapperScripts.sol
+++ b/src/WrapperScripts.sol
@@ -21,8 +21,7 @@ contract IWstETHActions {
         IWstETH(wrapper).wrap(amount);
     }
 
-    function unwrapLidoWstETH(address wrapper, address tokenToUnwrap, uint256 amount) external {
-        IERC20(tokenToUnwrap).approve(wrapper, amount);
+    function unwrapLidoWstETH(address wrapper, uint256 amount) external {
         IWstETH(wrapper).unwrap(amount);
     }
 }

--- a/src/builder/Accounts.sol
+++ b/src/builder/Accounts.sol
@@ -159,16 +159,17 @@ library Accounts {
             // Account for max cost if the payment token is the transfer token
             // Simply offset the max cost from the available asset batch
             if (payment.isToken && Strings.stringEqIgnoreCase(payment.currency, tokenSymbol)) {
-                // Use substractOrZero to prevent errors from underflowing
-                balance = Math.substractOrZero(balance, PaymentInfo.findMaxCost(payment, chainAccountsList[i].chainId));
+                // Use subtractFlooredAtZero to prevent errors from underflowing
+                balance =
+                    Math.subtractFlooredAtZero(balance, PaymentInfo.findMaxCost(payment, chainAccountsList[i].chainId));
             }
 
             // If the wrapper contract exists in the chain, add the balance of the wrapped/unwrapped token here as well
             // Offset with another max cost for wrapping/unwrapping action when the counter part is payment token
-            uint256 counterPartBalance = 0;
+            uint256 counterpartBalance = 0;
             if (TokenWrapper.hasWrapperContract(chainAccountsList[i].chainId, tokenSymbol)) {
                 // Add the balance of the wrapped token
-                counterPartBalance += Accounts.sumBalances(
+                counterpartBalance += Accounts.sumBalances(
                     Accounts.findAssetPositions(
                         TokenWrapper.getWrapperCounterpartSymbol(chainAccountsList[i].chainId, tokenSymbol),
                         chainAccountsList[i].chainId,
@@ -183,13 +184,13 @@ library Accounts {
                             TokenWrapper.getWrapperCounterpartSymbol(chainAccountsList[i].chainId, tokenSymbol)
                         )
                 ) {
-                    counterPartBalance = Math.substractOrZero(
-                        counterPartBalance, PaymentInfo.findMaxCost(payment, chainAccountsList[i].chainId)
+                    counterpartBalance = Math.subtractFlooredAtZero(
+                        counterpartBalance, PaymentInfo.findMaxCost(payment, chainAccountsList[i].chainId)
                     );
                 }
             }
 
-            total += balance + counterPartBalance;
+            total += balance + counterpartBalance;
         }
         return total;
     }

--- a/src/builder/Accounts.sol
+++ b/src/builder/Accounts.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 pragma solidity ^0.8.23;
 
+import {Math} from "src/lib/Math.sol";
 import {PaymentInfo} from "./PaymentInfo.sol";
 import {Strings} from "./Strings.sol";
 import {PaymentInfo} from "./PaymentInfo.sol";
@@ -158,14 +159,8 @@ library Accounts {
             // Account for max cost if the payment token is the transfer token
             // Simply offset the max cost from the available asset batch
             if (payment.isToken && Strings.stringEqIgnoreCase(payment.currency, tokenSymbol)) {
-                uint256 maxCost = PaymentInfo.findMaxCost(payment, chainAccountsList[i].chainId);
-
-                // Prevent errors from underflowing
-                if (balance >= maxCost) {
-                    balance -= maxCost;
-                } else {
-                    balance = 0;
-                }
+                // Use substractOrZero to prevent errors from underflowing
+                balance = Math.substractOrZero(balance, PaymentInfo.findMaxCost(payment, chainAccountsList[i].chainId));
             }
 
             // If the wrapper contract exists in the chain, add the balance of the wrapped/unwrapped token here as well
@@ -188,12 +183,9 @@ library Accounts {
                             TokenWrapper.getWrapperCounterpartSymbol(chainAccountsList[i].chainId, tokenSymbol)
                         )
                 ) {
-                    uint256 counterPartMaxCost = PaymentInfo.findMaxCost(payment, chainAccountsList[i].chainId);
-                    if (counterPartBalance >= counterPartMaxCost) {
-                        counterPartBalance -= counterPartMaxCost;
-                    } else {
-                        counterPartBalance = 0;
-                    }
+                    counterPartBalance = Math.substractOrZero(
+                        counterPartBalance, PaymentInfo.findMaxCost(payment, chainAccountsList[i].chainId)
+                    );
                 }
             }
 

--- a/src/builder/Actions.sol
+++ b/src/builder/Actions.sol
@@ -365,7 +365,7 @@ library Actions {
 
                     // Append wrap/unwrap action
                     if (counterpartTokenAmountToUseToBridge > 0) {
-                        (quarkOperations[actionIndex], actions[actionIndex]) = transformToWrapperConterpartAsset(
+                        (quarkOperations[actionIndex], actions[actionIndex]) = transformToConterpartAsset(
                             WrapOrUnwrapAsset({
                                 chainAccountsList: chainAccountsList,
                                 assetSymbol: bridgeInfo.assetSymbol,
@@ -656,7 +656,7 @@ library Actions {
         return (quarkOperation, action);
     }
 
-    function transformToWrapperConterpartAsset(
+    function transformToConterpartAsset(
         WrapOrUnwrapAsset memory wrapOrUnwrap,
         PaymentInfo.Payment memory payment,
         bool useQuotecall

--- a/src/builder/Actions.sol
+++ b/src/builder/Actions.sol
@@ -727,12 +727,19 @@ library Actions {
             toAssetSymbol: TokenWrapper.getWrapperContract(unwrap.chainId, unwrap.assetSymbol).underlyingSymbol
         });
 
+        string memory paymentMethod;
+        if (payment.isToken) {
+            // To pay with token, it has to be a paycall or quotecall.
+            paymentMethod = useQuotecall ? PAYMENT_METHOD_QUOTECALL : PAYMENT_METHOD_PAYCALL;
+        } else {
+            paymentMethod = PAYMENT_METHOD_OFFCHAIN;
+        }
         Action memory action = Actions.Action({
             chainId: unwrap.chainId,
             quarkAccount: unwrap.sender,
             actionType: ACTION_TYPE_UNWRAP,
             actionContext: abi.encode(wrapActionContext),
-            paymentMethod: payment.isToken ? PAYMENT_METHOD_PAYCALL : PAYMENT_METHOD_OFFCHAIN,
+            paymentMethod: paymentMethod,
             // Null address for OFFCHAIN payment.
             paymentToken: payment.isToken ? PaymentInfo.knownToken(payment.currency, unwrap.chainId).token : address(0),
             paymentTokenSymbol: payment.currency,
@@ -786,12 +793,19 @@ library Actions {
             toAssetSymbol: TokenWrapper.getWrapperContract(wrap.chainId, wrap.assetSymbol).wrappedSymbol
         });
 
+        string memory paymentMethod;
+        if (payment.isToken) {
+            // To pay with token, it has to be a paycall or quotecall.
+            paymentMethod = useQuotecall ? PAYMENT_METHOD_QUOTECALL : PAYMENT_METHOD_PAYCALL;
+        } else {
+            paymentMethod = PAYMENT_METHOD_OFFCHAIN;
+        }
         Action memory action = Actions.Action({
             chainId: wrap.chainId,
             quarkAccount: wrap.sender,
             actionType: ACTION_TYPE_WRAP,
             actionContext: abi.encode(wrapActionContext),
-            paymentMethod: payment.isToken ? PAYMENT_METHOD_PAYCALL : PAYMENT_METHOD_OFFCHAIN,
+            paymentMethod: paymentMethod,
             // Null address for OFFCHAIN payment.
             paymentToken: payment.isToken ? PaymentInfo.knownToken(payment.currency, wrap.chainId).token : address(0),
             paymentTokenSymbol: payment.currency,

--- a/src/builder/Actions.sol
+++ b/src/builder/Actions.sol
@@ -253,7 +253,7 @@ library Actions {
             Accounts.getBalanceOnChain(bridgeInfo.assetSymbol, bridgeInfo.dstChainId, chainAccountsList);
         uint256 amountLeftToBridge = bridgeInfo.amountNeededOnDst - balanceOnDstChain;
 
-        // Check on local chain if there is any wrapper counterpart token to grab before starts searching bridging routes
+        // Check to see if there are counterpart tokens on the destination chain that can be used. If there are, subtract the balance from `amountLeftToBridge`
         if (TokenWrapper.hasWrapperContract(bridgeInfo.dstChainId, bridgeInfo.assetSymbol)) {
             string memory counterpartSymbol =
                 TokenWrapper.getWrapperCounterpartSymbol(bridgeInfo.dstChainId, bridgeInfo.assetSymbol);
@@ -282,7 +282,7 @@ library Actions {
             }
 
             // NOTE: Only adjusts amount LeftToBridge
-            // The real wrappping/unwrapping will be done outside of the construct bridge operation function
+            // The real wrapping/unwrapping will be done outside of the construct bridge operation function
             // Update amountLeftToBridge
             amountLeftToBridge -= amountToWrapOrUnwrap;
         }

--- a/src/builder/Actions.sol
+++ b/src/builder/Actions.sol
@@ -224,7 +224,7 @@ library Actions {
         uint256 withdrawAmount;
     }
 
-    struct WrappingActionContext {
+    struct WrapActionContext {
         uint256 chainId;
         uint256 amount;
         address token;
@@ -283,10 +283,8 @@ library Actions {
 
             // NOTE: Only adjusts amount LeftToBridge
             // The real wrappping/unwrapping will be done outside of the construct bridge operation function
-            if (amountToWrapOrUnwrap > 0) {
-                // Update amountLeftToBridge
-                amountLeftToBridge -= amountToWrapOrUnwrap;
-            }
+            // Update amountLeftToBridge
+            amountLeftToBridge -= amountToWrapOrUnwrap;
         }
 
         uint256 bridgeActionCount = 0;
@@ -702,7 +700,7 @@ library Actions {
         IQuarkWallet.QuarkOperation memory quarkOperation = IQuarkWallet.QuarkOperation({
             nonce: accountState.quarkNextNonce,
             scriptAddress: CodeJarHelper.getCodeAddress(type(WrapperActions).creationCode),
-            scriptCalldata: TokenWrapper.encodeUnwrapToken(unwrap.chainId, unwrap.assetSymbol, unwrap.amount),
+            scriptCalldata: TokenWrapper.encodeActionToUnwrapToken(unwrap.chainId, unwrap.assetSymbol, unwrap.amount),
             scriptSources: scriptSources,
             expiry: unwrap.blockTimestamp + STANDARD_EXPIRY_BUFFER
         });
@@ -719,12 +717,12 @@ library Actions {
         }
 
         // Construct Action
-        WrappingActionContext memory wrapActionContext = WrappingActionContext({
+        WrapActionContext memory wrapActionContext = WrapActionContext({
             chainId: unwrap.chainId,
             amount: unwrap.amount,
             token: assetPositions.asset,
             fromAssetSymbol: assetPositions.symbol,
-            toAssetSymbol: TokenWrapper.getWrapperContract(unwrap.chainId, unwrap.assetSymbol).underlyingSymbol
+            toAssetSymbol: TokenWrapper.getKnownWrapperTokenPair(unwrap.chainId, unwrap.assetSymbol).underlyingSymbol
         });
 
         string memory paymentMethod;
@@ -768,7 +766,9 @@ library Actions {
         IQuarkWallet.QuarkOperation memory quarkOperation = IQuarkWallet.QuarkOperation({
             nonce: accountState.quarkNextNonce,
             scriptAddress: CodeJarHelper.getCodeAddress(type(WrapperActions).creationCode),
-            scriptCalldata: TokenWrapper.encodeWrapToken(wrap.chainId, wrap.assetSymbol, assetPositions.asset, wrap.amount),
+            scriptCalldata: TokenWrapper.encodeActionToWrapToken(
+                wrap.chainId, wrap.assetSymbol, assetPositions.asset, wrap.amount
+                ),
             scriptSources: scriptSources,
             expiry: wrap.blockTimestamp + STANDARD_EXPIRY_BUFFER
         });
@@ -785,12 +785,12 @@ library Actions {
         }
 
         // Construct Action
-        WrappingActionContext memory wrapActionContext = WrappingActionContext({
+        WrapActionContext memory wrapActionContext = WrapActionContext({
             chainId: wrap.chainId,
             amount: wrap.amount,
             token: assetPositions.asset,
             fromAssetSymbol: assetPositions.symbol,
-            toAssetSymbol: TokenWrapper.getWrapperContract(wrap.chainId, wrap.assetSymbol).wrappedSymbol
+            toAssetSymbol: TokenWrapper.getKnownWrapperTokenPair(wrap.chainId, wrap.assetSymbol).wrappedSymbol
         });
 
         string memory paymentMethod;

--- a/src/builder/Actions.sol
+++ b/src/builder/Actions.sol
@@ -281,38 +281,9 @@ library Actions {
                 }
             }
 
-            // Append wrap/unwrap action
+            // NOTE: Only adjusts amount LeftToBridge
+            // The real wrappping/unwrapping will be done outside of the construct bridge operation function
             if (amountToWrapOrUnwrap > 0) {
-                if (TokenWrapper.isWrappedToken(bridgeInfo.dstChainId, bridgeInfo.assetSymbol)) {
-                    (quarkOperations[actionIndex], actions[actionIndex]) = unwrapAsset(
-                        UnwrapAsset({
-                            chainAccountsList: chainAccountsList,
-                            assetSymbol: bridgeInfo.assetSymbol,
-                            amount: amountToWrapOrUnwrap,
-                            chainId: bridgeInfo.dstChainId,
-                            sender: bridgeInfo.recipient,
-                            blockTimestamp: bridgeInfo.blockTimestamp
-                        }),
-                        payment,
-                        bridgeInfo.useQuotecall
-                    );
-                    actionIndex++;
-                } else {
-                    (quarkOperations[actionIndex], actions[actionIndex]) = wrapAsset(
-                        WrapAsset({
-                            chainAccountsList: chainAccountsList,
-                            assetSymbol: bridgeInfo.assetSymbol,
-                            amount: amountToWrapOrUnwrap,
-                            chainId: bridgeInfo.dstChainId,
-                            sender: bridgeInfo.recipient,
-                            blockTimestamp: bridgeInfo.blockTimestamp
-                        }),
-                        payment,
-                        bridgeInfo.useQuotecall
-                    );
-                    actionIndex++;
-                }
-
                 // Update amountLeftToBridge
                 amountLeftToBridge -= amountToWrapOrUnwrap;
             }

--- a/src/builder/Actions.sol
+++ b/src/builder/Actions.sol
@@ -612,7 +612,7 @@ library Actions {
         return (quarkOperation, action);
     }
 
-    function transformToConterpartAsset(
+    function wrapOrUnwrapAsset(
         WrapOrUnwrapAsset memory wrapOrUnwrap,
         PaymentInfo.Payment memory payment,
         bool useQuotecall
@@ -631,7 +631,7 @@ library Actions {
         IQuarkWallet.QuarkOperation memory quarkOperation = IQuarkWallet.QuarkOperation({
             nonce: accountState.quarkNextNonce,
             scriptAddress: CodeJarHelper.getCodeAddress(type(WrapperActions).creationCode),
-            scriptCalldata: TokenWrapper.encodeActionToTransformToCounterpart(
+            scriptCalldata: TokenWrapper.encodeActionToWrapOrUnwrap(
                 wrapOrUnwrap.chainId, wrapOrUnwrap.assetSymbol, wrapOrUnwrap.amount
                 ),
             scriptSources: scriptSources,

--- a/src/builder/QuarkBuilder.sol
+++ b/src/builder/QuarkBuilder.sol
@@ -282,6 +282,7 @@ contract QuarkBuilder {
         // Check if need to wrap/unwrap token to cover the transferIntent amount
         // If the existing balance is not enough to cover the transferIntent amount, wrap/unwrap the counterpart token here
         // NOTE: We prioritize unwrap/wrap in the dst chain over bridging, bridging logic checks for counterpart tokens when calculating the amounts to bridge.
+        // TODO: Will also implement this logics in comet supply scenario
         uint256 existingBalance =
             Accounts.getBalanceOnChain(transferIntent.assetSymbol, transferIntent.chainId, chainAccountsList);
         if (

--- a/src/builder/QuarkBuilder.sol
+++ b/src/builder/QuarkBuilder.sol
@@ -476,7 +476,7 @@ contract QuarkBuilder {
             amountNeededOnDstChain += PaymentInfo.findMaxCost(payment, chainId);
         }
 
-        // If has wrap token counterpart, try to wrap/unwrap first before attempt to bridge
+        // If there exists a counterpart token, try to wrap/unwrap first before attempting to bridge
         uint256 wrapperCounterpartBalance = getWrapperCounterpartBalance(assetSymbol, chainId, chainAccountsList);
         // Subtract max cost if the counterpart token is the payment token
         if (

--- a/src/builder/QuarkBuilder.sol
+++ b/src/builder/QuarkBuilder.sol
@@ -574,10 +574,10 @@ contract QuarkBuilder {
                 Strings.stringEqIgnoreCase(nonBridgeAction.actionType, Actions.ACTION_TYPE_UNWRAP)
                     || Strings.stringEqIgnoreCase(nonBridgeAction.actionType, Actions.ACTION_TYPE_WRAP)
             ) {
-                Actions.WrappingActionContext memory wrappingActionContext =
-                    abi.decode(nonBridgeAction.actionContext, (Actions.WrappingActionContext));
-                if (Strings.stringEqIgnoreCase(wrappingActionContext.fromAssetSymbol, paymentTokenSymbol)) {
-                    paymentTokenCost += wrappingActionContext.amount;
+                Actions.WrapActionContext memory WrapActionContext =
+                    abi.decode(nonBridgeAction.actionContext, (Actions.WrapActionContext));
+                if (Strings.stringEqIgnoreCase(WrapActionContext.fromAssetSymbol, paymentTokenSymbol)) {
+                    paymentTokenCost += WrapActionContext.amount;
                 }
             } else {
                 revert InvalidActionType();

--- a/src/builder/QuarkBuilder.sol
+++ b/src/builder/QuarkBuilder.sol
@@ -295,7 +295,7 @@ contract QuarkBuilder {
                 TokenWrapper.getWrapperCounterpartSymbol(transferIntent.chainId, transferIntent.assetSymbol);
 
             // Wrap/unwrap the token to cover the transferIntent amount
-            (quarkOperations[actionIndex], actions[actionIndex]) = Actions.transformToConterpartAsset(
+            (quarkOperations[actionIndex], actions[actionIndex]) = Actions.wrapOrUnwrapAsset(
                 Actions.WrapOrUnwrapAsset({
                     chainAccountsList: chainAccountsList,
                     assetSymbol: counterpartSymbol,
@@ -574,7 +574,7 @@ contract QuarkBuilder {
                 // If the user opts for paying with payment token and the payment token is also the action token's counterpart
                 // reduce the available balance by the max cost
                 if (payment.isToken && Strings.stringEqIgnoreCase(payment.currency, counterpartSymbol)) {
-                    counterpartBalance = Math.substractOrZero(
+                    counterpartBalance = Math.subtractFlooredAtZero(
                         counterpartBalance, PaymentInfo.findMaxCost(payment, chainAccountsList[i].chainId)
                     );
                 }
@@ -628,7 +628,8 @@ contract QuarkBuilder {
                 )
         ) {
             // 0 if account can't afford to wrap/unwrap == can't use that balance
-            counterpartBalance = Math.substractOrZero(counterpartBalance, PaymentInfo.findMaxCost(payment, chainId));
+            counterpartBalance =
+                Math.subtractFlooredAtZero(counterpartBalance, PaymentInfo.findMaxCost(payment, chainId));
         }
         balanceOnChain += counterpartBalance;
 

--- a/src/builder/QuarkBuilder.sol
+++ b/src/builder/QuarkBuilder.sol
@@ -478,7 +478,7 @@ contract QuarkBuilder {
 
         // If has wrap token counterpart, try to wrap/unwrap first before attempt to bridge
         uint256 wrapperCounterpartBalance = getWrapperCounterpartBalance(assetSymbol, chainId, chainAccountsList);
-        // Substract max cost if the wrapper counter part is the payment token for wrap/unwrap action
+        // Subtract max cost if the counterpart token is the payment token
         if (
             payment.isToken
                 && Strings.stringEqIgnoreCase(

--- a/src/builder/QuarkBuilder.sol
+++ b/src/builder/QuarkBuilder.sol
@@ -399,22 +399,26 @@ contract QuarkBuilder {
                 if (payment.isToken && Strings.stringEqIgnoreCase(payment.currency, assetSymbol)) {
                     aggregateMaxCosts += PaymentInfo.findMaxCost(payment, chainAccountsList[i].chainId);
                 }
+            }
 
-                // If the asset has wrapper counterpart and can locally wrap/unwrap, accumulate the balance of the the counterpart
-                if (TokenWrapper.hasWrapperContract(chainAccountsList[i].chainId, assetSymbol)) {
-                    uint256 counterpartBalance =
-                        getWrapperCounterpartBalance(assetSymbol, chainAccountsList[i].chainId, chainAccountsList);
-                    string memory counterpartSymbol =
-                        TokenWrapper.getWrapperCounterpartSymbol(chainAccountsList[i].chainId, assetSymbol);
-                    // If the user opts for paying with payment token and the payment token is also the action token's counterpart
-                    // reduce the available balance by the max cost
-                    if (payment.isToken && Strings.stringEqIgnoreCase(payment.currency, counterpartSymbol)) {
-                        counterpartBalance = Math.substractOrZero(
-                            counterpartBalance, PaymentInfo.findMaxCost(payment, chainAccountsList[i].chainId)
-                        );
-                    }
-                    aggregateAssetBalance += counterpartBalance;
+            // If the asset has wrapper counterpart and can locally wrap/unwrap, accumulate the balance of the the counterpart
+            // NOTE: Currently only at dst chain, and will ignore all the counterpart balance in other chains
+            if (
+                chainAccountsList[i].chainId == chainId
+                    && TokenWrapper.hasWrapperContract(chainAccountsList[i].chainId, assetSymbol)
+            ) {
+                uint256 counterpartBalance =
+                    getWrapperCounterpartBalance(assetSymbol, chainAccountsList[i].chainId, chainAccountsList);
+                string memory counterpartSymbol =
+                    TokenWrapper.getWrapperCounterpartSymbol(chainAccountsList[i].chainId, assetSymbol);
+                // If the user opts for paying with payment token and the payment token is also the action token's counterpart
+                // reduce the available balance by the max cost
+                if (payment.isToken && Strings.stringEqIgnoreCase(payment.currency, counterpartSymbol)) {
+                    counterpartBalance = Math.substractOrZero(
+                        counterpartBalance, PaymentInfo.findMaxCost(payment, chainAccountsList[i].chainId)
+                    );
                 }
+                aggregateAssetBalance += counterpartBalance;
             }
         }
 

--- a/src/builder/QuarkBuilder.sol
+++ b/src/builder/QuarkBuilder.sol
@@ -295,7 +295,7 @@ contract QuarkBuilder {
                 TokenWrapper.getWrapperCounterpartSymbol(transferIntent.chainId, transferIntent.assetSymbol);
 
             // Wrap/unwrap the token to cover the transferIntent amount
-            (quarkOperations[actionIndex], actions[actionIndex]) = Actions.transformToWrapperConterpartAsset(
+            (quarkOperations[actionIndex], actions[actionIndex]) = Actions.transformToConterpartAsset(
                 Actions.WrapOrUnwrapAsset({
                     chainAccountsList: chainAccountsList,
                     assetSymbol: counterpartSymbol,

--- a/src/builder/QuarkBuilder.sol
+++ b/src/builder/QuarkBuilder.sol
@@ -12,7 +12,6 @@ import {PaycallWrapper} from "./PaycallWrapper.sol";
 import {QuotecallWrapper} from "./QuotecallWrapper.sol";
 import {PaymentInfo} from "./PaymentInfo.sol";
 import {TokenWrapper} from "./TokenWrapper.sol";
-import "forge-std/console.sol";
 
 contract QuarkBuilder {
     /* ===== Constants ===== */

--- a/src/builder/TokenWrapper.sol
+++ b/src/builder/TokenWrapper.sol
@@ -43,7 +43,7 @@ library TokenWrapper {
         return pairs;
     }
 
-    function getWrapperContract(uint256 chainId, string memory tokenSymbol)
+    function getKnownWrapperTokenPair(uint256 chainId, string memory tokenSymbol)
         internal
         pure
         returns (KnownWrapperTokenPair memory wrapper)
@@ -63,17 +63,16 @@ library TokenWrapper {
     }
 
     function hasWrapperContract(uint256 chainId, string memory tokenSymbol) internal pure returns (bool) {
-        return getWrapperContract(chainId, tokenSymbol).wrapper != address(0);
+        return getKnownWrapperTokenPair(chainId, tokenSymbol).wrapper != address(0);
     }
 
     function getWrapperCounterpartSymbol(uint256 chainId, string memory assetSymbol)
         internal
         pure
-        returns (string memory counterpartSymbol)
+        returns (string memory)
     {
-        // If is wrappable token, accumulate the balance of the the counterpart
         if (hasWrapperContract(chainId, assetSymbol)) {
-            KnownWrapperTokenPair memory p = getWrapperContract(chainId, assetSymbol);
+            KnownWrapperTokenPair memory p = getKnownWrapperTokenPair(chainId, assetSymbol);
             if (isWrappedToken(chainId, assetSymbol)) {
                 return p.underlyingSymbol;
             } else {
@@ -86,22 +85,22 @@ library TokenWrapper {
     }
 
     function isWrappedToken(uint256 chainId, string memory tokenSymbol) internal pure returns (bool) {
-        return Strings.stringEqIgnoreCase(tokenSymbol, getWrapperContract(chainId, tokenSymbol).wrappedSymbol);
+        return Strings.stringEqIgnoreCase(tokenSymbol, getKnownWrapperTokenPair(chainId, tokenSymbol).wrappedSymbol);
     }
 
-    function encodeWrapToken(uint256 chainId, string memory tokenSymbol, address tokenAddress, uint256 amount)
+    function encodeActionToWrapToken(uint256 chainId, string memory tokenSymbol, address tokenAddress, uint256 amount)
         internal
         pure
         returns (bytes memory)
     {
         if (Strings.stringEqIgnoreCase(tokenSymbol, "ETH")) {
             return abi.encodeWithSelector(
-                WrapperActions.wrapETH.selector, getWrapperContract(chainId, tokenSymbol).wrapper, amount
+                WrapperActions.wrapETH.selector, getKnownWrapperTokenPair(chainId, tokenSymbol).wrapper, amount
             );
         } else if (Strings.stringEqIgnoreCase(tokenSymbol, "stETH")) {
             return abi.encodeWithSelector(
                 WrapperActions.wrapLidoStETH.selector,
-                getWrapperContract(chainId, tokenSymbol).wrapper,
+                getKnownWrapperTokenPair(chainId, tokenSymbol).wrapper,
                 tokenAddress,
                 amount
             );
@@ -109,18 +108,18 @@ library TokenWrapper {
         revert NotWrappable();
     }
 
-    function encodeUnwrapToken(uint256 chainId, string memory tokenSymbol, uint256 amount)
+    function encodeActionToUnwrapToken(uint256 chainId, string memory tokenSymbol, uint256 amount)
         internal
         pure
         returns (bytes memory)
     {
         if (Strings.stringEqIgnoreCase(tokenSymbol, "WETH")) {
             return abi.encodeWithSelector(
-                WrapperActions.unwrapWETH.selector, getWrapperContract(chainId, tokenSymbol).wrapper, amount
+                WrapperActions.unwrapWETH.selector, getKnownWrapperTokenPair(chainId, tokenSymbol).wrapper, amount
             );
         } else if (Strings.stringEqIgnoreCase(tokenSymbol, "wstETH")) {
             return abi.encodeWithSelector(
-                WrapperActions.unwrapLidoWstETH.selector, getWrapperContract(chainId, tokenSymbol).wrapper, amount
+                WrapperActions.unwrapLidoWstETH.selector, getKnownWrapperTokenPair(chainId, tokenSymbol).wrapper, amount
             );
         }
         revert NotUnwrappable();

--- a/src/builder/TokenWrapper.sol
+++ b/src/builder/TokenWrapper.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity ^0.8.23;
+
+import "./Strings.sol";
+
+library TokenWrapper {
+
+    struct KnownWrappedTokenPair {
+        uint256 chainId;
+        address wrapper;
+        string underlyingSymbol;
+        string wrappedSymbol;
+    }
+
+    function knownWrappedTokenPairs() internal pure returns (KnownWrappedTokenPair[] memory) {
+        KnownWrappedTokenPair[] memory pairs = new KnownWrappedTokenPair[](4);
+        pairs[0] = KnownWrappedTokenPair({chainId: 1, wrapper: 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984, underlyingSymbol: "ETH", wrappedSymbol: "WETH"});
+        pairs[1] = KnownWrappedTokenPair({chainId: 8453, wrapper: 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984, underlyingSymbol: "ETH", wrappedSymbol: "WETH"});
+        pairs[2] = KnownWrappedTokenPair({chainId: 1, wrapper: 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984, underlyingSymbol: "ETH", wrappedSymbol: "WETH"});
+        pairs[3] = KnownWrappedTokenPair({chainId: 8453, wrapper: 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984, underlyingSymbol: "ETH", wrappedSymbol: "WETH"});
+        return pairs;
+    }
+
+    function hasWrappedVersion(string memory tokenSymbol) internal pure returns (bool) {
+        return Strings.stringEqIgnoreCase(tokenSymbol, "USDC");
+    }
+
+    function hasUnwrappedVersion(string memory tokenSymbol) internal pure returns (bool) {
+        return Strings.stringEqIgnoreCase(tokenSymbol, "WUSDC");
+    }
+
+}

--- a/src/builder/TokenWrapper.sol
+++ b/src/builder/TokenWrapper.sol
@@ -37,7 +37,7 @@ library TokenWrapper {
         });
         // NOTE: Leave out stETH and wstETH auto wrapper for now
         // TODO: Need to figure a way out to compute the "correct" ratio between stETH and wstETH for QuarkBuilder
-        // Because QuarkBuilder doesn't have access to on-chain data, but eht ratio between stETH and wstETH is constantly changing,
+        // Because QuarkBuilder doesn't have access to on-chain data, but the ratio between stETH and wstETH is constantly changing,
         // which will be hard if we need to use it to compute the absolute number of wstETH to unwrap into stETH or vice versa
         //
         // pairs[2] = KnownWrapperTokenPair({

--- a/src/builder/TokenWrapper.sol
+++ b/src/builder/TokenWrapper.sol
@@ -16,7 +16,7 @@ library TokenWrapper {
     }
 
     function knownWrapperTokenPairs() internal pure returns (KnownWrapperTokenPair[] memory) {
-        KnownWrapperTokenPair[] memory pairs = new KnownWrapperTokenPair[](4);
+        KnownWrapperTokenPair[] memory pairs = new KnownWrapperTokenPair[](2);
         pairs[0] = KnownWrapperTokenPair({
             chainId: 1,
             wrapper: 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2,
@@ -29,12 +29,17 @@ library TokenWrapper {
             underlyingSymbol: "ETH",
             wrappedSymbol: "WETH"
         });
-        pairs[2] = KnownWrapperTokenPair({
-            chainId: 1,
-            wrapper: 0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0,
-            underlyingSymbol: "stETH",
-            wrappedSymbol: "wstETH"
-        });
+        // NOTE: Leave out stETH and wstETH auto wrapper for now
+        // TODO: Need to figure a way out to compute the "correct" ratio between stETH and wstETH for QuarkBuilder
+        // Because QuarkBuilder doesn't have access to on-chain data, but eht ratio between stETH and wstETH is constantly changing, 
+        // which will be hard if we need to use it to compute the absolute number of wstETH to unwrap into stETH or vice versa
+        //
+        // pairs[2] = KnownWrapperTokenPair({
+        //     chainId: 1,
+        //     wrapper: 0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0,
+        //     underlyingSymbol: "stETH",
+        //     wrappedSymbol: "wstETH"
+        // });
         return pairs;
     }
 

--- a/src/builder/TokenWrapper.sol
+++ b/src/builder/TokenWrapper.sol
@@ -94,7 +94,7 @@ library TokenWrapper {
         return Strings.stringEqIgnoreCase(tokenSymbol, getKnownWrapperTokenPair(chainId, tokenSymbol).wrappedSymbol);
     }
 
-    function encodeActionToTransformToCounterpart(uint256 chainId, string memory tokenSymbol, uint256 amount)
+    function encodeActionToWrapOrUnwrap(uint256 chainId, string memory tokenSymbol, uint256 amount)
         internal
         pure
         returns (bytes memory)

--- a/src/builder/TokenWrapper.sol
+++ b/src/builder/TokenWrapper.sol
@@ -14,18 +14,17 @@ library TokenWrapper {
 
     function knownWrappedTokenPairs() internal pure returns (KnownWrappedTokenPair[] memory) {
         KnownWrappedTokenPair[] memory pairs = new KnownWrappedTokenPair[](4);
-        pairs[0] = KnownWrappedTokenPair({chainId: 1, wrapper: 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984, underlyingSymbol: "ETH", wrappedSymbol: "WETH"});
-        pairs[1] = KnownWrappedTokenPair({chainId: 8453, wrapper: 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984, underlyingSymbol: "ETH", wrappedSymbol: "WETH"});
-        pairs[2] = KnownWrappedTokenPair({chainId: 1, wrapper: 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984, underlyingSymbol: "ETH", wrappedSymbol: "WETH"});
-        pairs[3] = KnownWrappedTokenPair({chainId: 8453, wrapper: 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984, underlyingSymbol: "ETH", wrappedSymbol: "WETH"});
+        pairs[0] = KnownWrappedTokenPair({chainId: 1, wrapper: 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, underlyingSymbol: "ETH", wrappedSymbol: "WETH"});
+        pairs[1] = KnownWrappedTokenPair({chainId: 8453, wrapper: 0x4200000000000000000000000000000000000006, underlyingSymbol: "ETH", wrappedSymbol: "WETH"});
+        pairs[2] = KnownWrappedTokenPair({chainId: 1, wrapper: 0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0, underlyingSymbol: "stETH", wrappedSymbol: "wstETH"});
         return pairs;
     }
 
-    function hasWrappedVersion(string memory tokenSymbol) internal pure returns (bool) {
+    function hasWrappedVersion(uint256 chainId, string memory tokenSymbol) internal pure returns (bool) {
         return Strings.stringEqIgnoreCase(tokenSymbol, "USDC");
     }
 
-    function hasUnwrappedVersion(string memory tokenSymbol) internal pure returns (bool) {
+    function hasUnwrappedVersion(uint256 chainId, string memory tokenSymbol) internal pure returns (bool) {
         return Strings.stringEqIgnoreCase(tokenSymbol, "WUSDC");
     }
 

--- a/src/builder/TokenWrapper.sol
+++ b/src/builder/TokenWrapper.sol
@@ -2,30 +2,81 @@
 pragma solidity ^0.8.23;
 
 import "./Strings.sol";
+import {IWETHActions, IWstETHActions} from "../WrapperScripts.sol";
 
 library TokenWrapper {
-
-    struct KnownWrappedTokenPair {
+    struct KnownWrapperTokenPair {
         uint256 chainId;
         address wrapper;
         string underlyingSymbol;
         string wrappedSymbol;
     }
 
-    function knownWrappedTokenPairs() internal pure returns (KnownWrappedTokenPair[] memory) {
-        KnownWrappedTokenPair[] memory pairs = new KnownWrappedTokenPair[](4);
-        pairs[0] = KnownWrappedTokenPair({chainId: 1, wrapper: 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, underlyingSymbol: "ETH", wrappedSymbol: "WETH"});
-        pairs[1] = KnownWrappedTokenPair({chainId: 8453, wrapper: 0x4200000000000000000000000000000000000006, underlyingSymbol: "ETH", wrappedSymbol: "WETH"});
-        pairs[2] = KnownWrappedTokenPair({chainId: 1, wrapper: 0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0, underlyingSymbol: "stETH", wrappedSymbol: "wstETH"});
+    function knownWrapperTokenPairs() internal pure returns (KnownWrapperTokenPair[] memory) {
+        KnownWrapperTokenPair[] memory pairs = new KnownWrapperTokenPair[](4);
+        pairs[0] = KnownWrapperTokenPair({
+            chainId: 1,
+            wrapper: 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2,
+            underlyingSymbol: "ETH",
+            wrappedSymbol: "WETH"
+        });
+        pairs[1] = KnownWrapperTokenPair({
+            chainId: 8453,
+            wrapper: 0x4200000000000000000000000000000000000006,
+            underlyingSymbol: "ETH",
+            wrappedSymbol: "WETH"
+        });
+        pairs[2] = KnownWrapperTokenPair({
+            chainId: 1,
+            wrapper: 0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0,
+            underlyingSymbol: "stETH",
+            wrappedSymbol: "wstETH"
+        });
         return pairs;
     }
 
-    function hasWrappedVersion(uint256 chainId, string memory tokenSymbol) internal pure returns (bool) {
-        return Strings.stringEqIgnoreCase(tokenSymbol, "USDC");
+    function getWrapperContract(uint256 chainId, string memory tokenSymbol)
+        internal
+        pure
+        returns (KnownWrapperTokenPair memory wrapper)
+    {
+        for (uint256 i = 0; i < knownWrapperTokenPairs().length; i++) {
+            KnownWrapperTokenPair memory pair = knownWrapperTokenPairs()[i];
+            if (
+                pair.chainId == chainId
+                    && (
+                        Strings.stringEqIgnoreCase(tokenSymbol, pair.underlyingSymbol)
+                            || Strings.stringEqIgnoreCase(tokenSymbol, pair.wrappedSymbol)
+                    )
+            ) {
+                return wrapper = pair;
+            }
+        }
     }
 
-    function hasUnwrappedVersion(uint256 chainId, string memory tokenSymbol) internal pure returns (bool) {
-        return Strings.stringEqIgnoreCase(tokenSymbol, "WUSDC");
+    function hasWrapperContract(uint256 chainId, string memory tokenSymbol) internal pure returns (bool) {
+        return getWrapperContract(chainId, tokenSymbol).wrapper != address(0);
     }
 
+    function isWrappedToken(uint256 chainId, string memory tokenSymbol) internal pure returns (bool) {
+        return Strings.stringEqIgnoreCase(tokenSymbol, getWrapperContract(chainId, tokenSymbol).wrappedSymbol);
+    }
+
+    function encodeWrapToken(uint256 chainId, string memory tokenSymbol, uint256 amount)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        KnownWrapperTokenPair memory wrapper = getWrapperContract(chainId, tokenSymbol);
+        return abi.encodeWithSignature("wrap(address,uint256)", wrapper.wrapper, amount);
+    }
+
+    function encodeUnwrapToken(uint256 chainId, string memory tokenSymbol, uint256 amount)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        KnownWrapperTokenPair memory wrapper = getWrapperContract(chainId, tokenSymbol);
+        return abi.encodeWithSignature("unwrap(address,uint256)", wrapper.wrapper, amount);
+    }
 }

--- a/src/builder/TokenWrapper.sol
+++ b/src/builder/TokenWrapper.sol
@@ -31,7 +31,7 @@ library TokenWrapper {
         });
         // NOTE: Leave out stETH and wstETH auto wrapper for now
         // TODO: Need to figure a way out to compute the "correct" ratio between stETH and wstETH for QuarkBuilder
-        // Because QuarkBuilder doesn't have access to on-chain data, but eht ratio between stETH and wstETH is constantly changing, 
+        // Because QuarkBuilder doesn't have access to on-chain data, but eht ratio between stETH and wstETH is constantly changing,
         // which will be hard if we need to use it to compute the absolute number of wstETH to unwrap into stETH or vice versa
         //
         // pairs[2] = KnownWrapperTokenPair({

--- a/src/interfaces/IWstETH.sol
+++ b/src/interfaces/IWstETH.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity 0.8.23;
+
+interface IWstETH {
+    function wrap(uint256 amount) external returns (uint256);
+    function unwrap(uint256 amount) external returns (uint256);
+}

--- a/src/lib/Math.sol
+++ b/src/lib/Math.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity 0.8.23;
+
+library Math {
+    function substractOrZero(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a > b ? a - b : 0;
+    }
+}

--- a/src/lib/Math.sol
+++ b/src/lib/Math.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.23;
 
 library Math {
-    function substractOrZero(uint256 a, uint256 b) internal pure returns (uint256) {
+    function subtractFlooredAtZero(uint256 a, uint256 b) internal pure returns (uint256) {
         return a > b ? a - b : 0;
     }
 }

--- a/test/WrapperScripts.t.sol
+++ b/test/WrapperScripts.t.sol
@@ -58,6 +58,7 @@ contract WrapperScriptsTest is Test {
             ScriptType.ScriptSource
         );
         (uint8 v, bytes32 r, bytes32 s) = new SignatureHelper().signOp(alicePrivateKey, wallet, op);
+
         assertEq(IERC20(WETH).balanceOf(address(wallet)), 0 ether);
         assertEq(address(wallet).balance, 10 ether);
         vm.resumeGasMetering();
@@ -66,7 +67,7 @@ contract WrapperScriptsTest is Test {
         assertEq(address(wallet).balance, 0 ether);
     }
 
-    function testUnwraWETH() public {
+    function testUnwrapWETH() public {
         vm.pauseGasMetering();
         QuarkWallet wallet = QuarkWallet(factory.create(alice, address(0)));
 
@@ -79,6 +80,7 @@ contract WrapperScriptsTest is Test {
             ScriptType.ScriptSource
         );
         (uint8 v, bytes32 r, bytes32 s) = new SignatureHelper().signOp(alicePrivateKey, wallet, op);
+
         assertEq(IERC20(WETH).balanceOf(address(wallet)), 10 ether);
         assertEq(address(wallet).balance, 0 ether);
         vm.resumeGasMetering();
@@ -105,6 +107,7 @@ contract WrapperScriptsTest is Test {
             ScriptType.ScriptSource
         );
         (uint8 v, bytes32 r, bytes32 s) = new SignatureHelper().signOp(alicePrivateKey, wallet, op);
+
         assertEq(IERC20(wstETH).balanceOf(address(wallet)), 0 ether);
         assertApproxEqAbs(IERC20(stETH).balanceOf(address(wallet)), 10 ether, 0.01 ether);
         vm.resumeGasMetering();
@@ -126,6 +129,7 @@ contract WrapperScriptsTest is Test {
             ScriptType.ScriptSource
         );
         (uint8 v, bytes32 r, bytes32 s) = new SignatureHelper().signOp(alicePrivateKey, wallet, op);
+
         assertEq(IERC20(stETH).balanceOf(address(wallet)), 0 ether);
         assertEq(IERC20(wstETH).balanceOf(address(wallet)), 10 ether);
         vm.resumeGasMetering();

--- a/test/WrapperScripts.t.sol
+++ b/test/WrapperScripts.t.sol
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity 0.8.23;
+
+import "forge-std/Test.sol";
+import "forge-std/console.sol";
+import "forge-std/StdUtils.sol";
+import "forge-std/StdMath.sol";
+
+import {CodeJar} from "codejar/src/CodeJar.sol";
+
+import {QuarkWallet} from "quark-core/src/QuarkWallet.sol";
+import {QuarkStateManager} from "quark-core/src/QuarkStateManager.sol";
+
+import {QuarkWalletProxyFactory} from "quark-proxy/src/QuarkWalletProxyFactory.sol";
+
+import {YulHelper} from "./lib/YulHelper.sol";
+import {SignatureHelper} from "./lib/SignatureHelper.sol";
+import {QuarkOperationHelper, ScriptType} from "./lib/QuarkOperationHelper.sol";
+import {IStETH} from "./lib/IStETH.sol";
+
+import "src/WrapperScripts.sol";
+
+/**
+ * Tests for supplying assets to Comet
+ */
+contract WrapperScriptsTest is Test {
+    QuarkWalletProxyFactory public factory;
+    uint256 alicePrivateKey = 0xa11ce;
+    address alice = vm.addr(alicePrivateKey);
+
+    // Contracts address on mainnet
+    address constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+    address constant stETH = 0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84;
+    address constant wstETH = 0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0;
+    bytes wrapperScript = new YulHelper().getCode("WrapperScripts.sol/WrapperActions.json");
+
+    function setUp() public {
+        // Fork setup
+        vm.createSelectFork(
+            string.concat(
+                "https://node-provider.compound.finance/ethereum-mainnet/", vm.envString("NODE_PROVIDER_BYPASS_KEY")
+            ),
+            18429607 // 2023-10-25 13:24:00 PST
+        );
+        factory = new QuarkWalletProxyFactory(address(new QuarkWallet(new CodeJar(), new QuarkStateManager())));
+    }
+
+    function testWrapETH() public {
+        vm.pauseGasMetering();
+        QuarkWallet wallet = QuarkWallet(factory.create(alice, address(0)));
+
+        deal(address(wallet), 10 ether);
+
+        QuarkWallet.QuarkOperation memory op = new QuarkOperationHelper().newBasicOpWithCalldata(
+            wallet,
+            wrapperScript,
+            abi.encodeWithSelector(WrapperActions.wrapETH.selector, WETH, 10 ether),
+            ScriptType.ScriptSource
+        );
+        (uint8 v, bytes32 r, bytes32 s) = new SignatureHelper().signOp(alicePrivateKey, wallet, op);
+        assertEq(IERC20(WETH).balanceOf(address(wallet)), 0 ether);
+        assertEq(address(wallet).balance, 10 ether);
+        vm.resumeGasMetering();
+        wallet.executeQuarkOperation(op, v, r, s);
+        assertEq(IERC20(WETH).balanceOf(address(wallet)), 10 ether);
+        assertEq(address(wallet).balance, 0 ether);
+    }
+
+    function testUnwraWETH() public {
+        vm.pauseGasMetering();
+        QuarkWallet wallet = QuarkWallet(factory.create(alice, address(0)));
+
+        deal(WETH, address(wallet), 10 ether);
+
+        QuarkWallet.QuarkOperation memory op = new QuarkOperationHelper().newBasicOpWithCalldata(
+            wallet,
+            wrapperScript,
+            abi.encodeWithSelector(WrapperActions.unwrapWETH.selector, WETH, 10 ether),
+            ScriptType.ScriptSource
+        );
+        (uint8 v, bytes32 r, bytes32 s) = new SignatureHelper().signOp(alicePrivateKey, wallet, op);
+        assertEq(IERC20(WETH).balanceOf(address(wallet)), 10 ether);
+        assertEq(address(wallet).balance, 0 ether);
+        vm.resumeGasMetering();
+        wallet.executeQuarkOperation(op, v, r, s);
+        assertEq(IERC20(WETH).balanceOf(address(wallet)), 0 ether);
+        assertEq(address(wallet).balance, 10 ether);
+    }
+
+    function testWrapStETH() public {
+        vm.pauseGasMetering();
+        QuarkWallet wallet = QuarkWallet(factory.create(alice, address(0)));
+
+        // Special balance computation in Lido, have to do regular staking action to not mess up the Lido's contract
+        deal(address(wallet), 10 ether);
+        vm.startPrank(address(wallet));
+        // Call Lido's submit() to stake
+        IStETH(stETH).submit{value: 10 ether}(address(0));
+        vm.stopPrank();
+
+        QuarkWallet.QuarkOperation memory op = new QuarkOperationHelper().newBasicOpWithCalldata(
+            wallet,
+            wrapperScript,
+            abi.encodeWithSelector(WrapperActions.wrapLidoStETH.selector, wstETH, stETH, 10 ether),
+            ScriptType.ScriptSource
+        );
+        (uint8 v, bytes32 r, bytes32 s) = new SignatureHelper().signOp(alicePrivateKey, wallet, op);
+        assertEq(IERC20(wstETH).balanceOf(address(wallet)), 0 ether);
+        assertApproxEqAbs(IERC20(stETH).balanceOf(address(wallet)), 10 ether, 0.01 ether);
+        vm.resumeGasMetering();
+        wallet.executeQuarkOperation(op, v, r, s);
+        assertEq(IERC20(stETH).balanceOf(address(wallet)), 0 ether);
+        assertApproxEqAbs(IERC20(wstETH).balanceOf(address(wallet)), 8.74 ether, 0.01 ether);
+    }
+
+    function testUnwrapWstETH() public {
+        vm.pauseGasMetering();
+        QuarkWallet wallet = QuarkWallet(factory.create(alice, address(0)));
+
+        deal(wstETH, address(wallet), 10 ether);
+
+        QuarkWallet.QuarkOperation memory op = new QuarkOperationHelper().newBasicOpWithCalldata(
+            wallet,
+            wrapperScript,
+            abi.encodeWithSelector(WrapperActions.unwrapLidoWstETH.selector, wstETH, 10 ether),
+            ScriptType.ScriptSource
+        );
+        (uint8 v, bytes32 r, bytes32 s) = new SignatureHelper().signOp(alicePrivateKey, wallet, op);
+        assertEq(IERC20(stETH).balanceOf(address(wallet)), 0 ether);
+        assertEq(IERC20(wstETH).balanceOf(address(wallet)), 10 ether);
+        vm.resumeGasMetering();
+        wallet.executeQuarkOperation(op, v, r, s);
+        assertApproxEqAbs(IERC20(stETH).balanceOf(address(wallet)), 11.44 ether, 0.01 ether);
+        assertEq(IERC20(wstETH).balanceOf(address(wallet)), 0 ether);
+    }
+}

--- a/test/builder/QuarkBuilderTransfer.t.sol
+++ b/test/builder/QuarkBuilderTransfer.t.sol
@@ -894,7 +894,7 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         );
     }
 
-    function testTransferWithAutoWrapping() public {
+    function testTransferWithAutoUnwrapping() public {
         QuarkBuilder builder = new QuarkBuilder();
         address account = address(0xa11ce);
         PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](1);
@@ -1018,7 +1018,7 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         assertNotEq(result.eip712Data.hashStruct, hex"", "non-empty hashStruct");
     }
 
-    function testTransferWithAutoWrapppingWithPaycallSucceeds() public {
+    function testTransferWithAutoUnwrapppingWithPaycallSucceeds() public {
         QuarkBuilder builder = new QuarkBuilder();
         address account = address(0xa11ce);
         PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](1);
@@ -1155,7 +1155,7 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         assertNotEq(result.eip712Data.hashStruct, hex"", "non-empty hashStruct");
     }
 
-    function testTranfserMaxWithAutoWrapping() public {
+    function testTranfserMaxWithAutoUnwrapping() public {
         QuarkBuilder builder = new QuarkBuilder();
         address account = address(0xa11ce);
         PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](1);
@@ -1281,6 +1281,128 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
                     price: 3500e8,
                     token: eth_(),
                     assetSymbol: "ETH",
+                    chainId: 1,
+                    recipient: address(0xceecee)
+                })
+            ),
+            "action context encoded from TransferActionContext"
+        );
+
+        // TODO: Check the contents of the EIP712 data
+        assertNotEq(result.eip712Data.digest, hex"", "non-empty digest");
+        assertNotEq(result.eip712Data.domainSeparator, hex"", "non-empty domain separator");
+        assertNotEq(result.eip712Data.hashStruct, hex"", "non-empty hashStruct");
+    }
+
+    function testTransferWithAutoWrapping() public {
+        QuarkBuilder builder = new QuarkBuilder();
+        address account = address(0xa11ce);
+        PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](1);
+        maxCosts[0] = PaymentInfo.PaymentMaxCost({chainId: 1, amount: 1e5});
+        Accounts.ChainAccounts[] memory chainAccountsList = new Accounts.ChainAccounts[](1);
+        // Holding 10 USDC, 1ETH, and 1WETH on chain 1
+        Accounts.AssetPositions[] memory assetPositionsList = new Accounts.AssetPositions[](3);
+        assetPositionsList[0] = Accounts.AssetPositions({
+            asset: usdc_(1),
+            symbol: "USDC",
+            decimals: 6,
+            usdPrice: 1_0000_0000,
+            accountBalances: accountBalances_(account, 10e6)
+        });
+        assetPositionsList[1] = Accounts.AssetPositions({
+            asset: eth_(),
+            symbol: "ETH",
+            decimals: 18,
+            usdPrice: 3500_0000_0000,
+            accountBalances: accountBalances_(account, 1e18)
+        });
+        assetPositionsList[2] = Accounts.AssetPositions({
+            asset: weth_(1),
+            symbol: "WETH",
+            decimals: 18,
+            usdPrice: 3500_0000_0000,
+            accountBalances: accountBalances_(account, 1e18)
+        });
+
+        chainAccountsList[0] = Accounts.ChainAccounts({
+            chainId: 1,
+            quarkStates: quarkStates_(address(0xa11ce), 12),
+            assetPositionsList: assetPositionsList
+        });
+
+        // Transfer 1.5ETH to 0xceecee on chain 1
+        // Should able to have auto unwrapping 0.5 WETH to ETH to cover the amount
+        QuarkBuilder.BuilderResult memory result = builder.transfer(
+            transferWeth_(1, 1.75e18, address(0xceecee), BLOCK_TIMESTAMP), chainAccountsList, paymentUsd_()
+        );
+
+        address transferActionsAddress = CodeJarHelper.getCodeAddress(type(TransferActions).creationCode);
+        address wrapperActionsAddress = CodeJarHelper.getCodeAddress(type(WrapperActions).creationCode);
+
+        assertEq(result.version, "1.0.0", "version 1");
+        assertEq(result.paymentCurrency, "usd", "usd currency");
+
+        // Check the quark operations
+        assertEq(result.quarkOperations.length, 2, "two operations");
+        assertEq(
+            result.quarkOperations[0].scriptAddress,
+            wrapperActionsAddress,
+            "script address is correct given the code jar address on mainnet"
+        );
+        assertEq(
+            result.quarkOperations[0].scriptCalldata,
+            abi.encodeWithSelector(WrapperActions.wrapETH.selector, 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, 0.75e18),
+            "calldata is WrapperActions.wrapWETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, 0.75e18);"
+        );
+        assertEq(
+            result.quarkOperations[1].scriptAddress,
+            transferActionsAddress,
+            "script address is correct given the code jar address on mainnet"
+        );
+        assertEq(
+            result.quarkOperations[1].scriptCalldata,
+            abi.encodeWithSelector(TransferActions.transferERC20Token.selector, WETH_1, address(0xceecee), 1.75e18),
+            "calldata is TransferActions.transferERC20Token(WETH_1, address(0xceecee), 1.75e18);"
+        );
+        assertEq(
+            result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
+        );
+        assertEq(
+            result.quarkOperations[1].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
+        );
+        // check the actions
+        assertEq(result.actions.length, 2, "2 actions");
+        assertEq(result.actions[0].chainId, 1, "operation is on chainid 1");
+        assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce wrap the ETH");
+        assertEq(result.actions[0].actionType, "WRAP", "action type is 'WRAP'");
+        assertEq(result.actions[0].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
+        assertEq(result.actions[0].paymentToken, address(0), "payment token is USD");
+        assertEq(
+            result.actions[0].actionContext,
+            abi.encode(
+                Actions.WrappingActionContext({
+                    chainId: 1,
+                    amount: 0.75e18,
+                    token: eth_(),
+                    fromAssetSymbol: "ETH",
+                    toAssetSymbol: "WETH"
+                })
+            ),
+            "action context encoded from WrappingActionContext"
+        );
+        assertEq(result.actions[1].chainId, 1, "operation is on chainid 1");
+        assertEq(result.actions[1].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
+        assertEq(result.actions[1].actionType, "TRANSFER", "action type is 'TRANSFER'");
+        assertEq(result.actions[1].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
+        assertEq(result.actions[1].paymentToken, address(0), "payment token is USD");
+        assertEq(
+            result.actions[1].actionContext,
+            abi.encode(
+                Actions.TransferActionContext({
+                    amount: 1.75e18,
+                    price: 3500e8,
+                    token: weth_(1),
+                    assetSymbol: "WETH",
                     chainId: 1,
                     recipient: address(0xceecee)
                 })

--- a/test/builder/QuarkBuilderTransfer.t.sol
+++ b/test/builder/QuarkBuilderTransfer.t.sol
@@ -982,7 +982,7 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         assertEq(
             result.actions[0].actionContext,
             abi.encode(
-                Actions.WrapActionContext({
+                Actions.WrapOrUnwrapActionContext({
                     chainId: 1,
                     amount: 0.5e18,
                     token: weth_(1),
@@ -990,7 +990,7 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
                     toAssetSymbol: "ETH"
                 })
             ),
-            "action context encoded from WrapActionContext"
+            "action context encoded from WrapOrUnwrapActionContext"
         );
         assertEq(result.actions[1].chainId, 1, "operation is on chainid 1");
         assertEq(result.actions[1].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
@@ -1119,7 +1119,7 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         assertEq(
             result.actions[0].actionContext,
             abi.encode(
-                Actions.WrapActionContext({
+                Actions.WrapOrUnwrapActionContext({
                     chainId: 1,
                     amount: 0.5e18,
                     token: weth_(1),
@@ -1127,7 +1127,7 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
                     toAssetSymbol: "ETH"
                 })
             ),
-            "action context encoded from WrapActionContext"
+            "action context encoded from WrapOrUnwrapActionContext"
         );
         assertEq(result.actions[1].chainId, 1, "operation is on chainid 1");
         assertEq(result.actions[1].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
@@ -1258,7 +1258,7 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         assertEq(
             result.actions[0].actionContext,
             abi.encode(
-                Actions.WrapActionContext({
+                Actions.WrapOrUnwrapActionContext({
                     chainId: 1,
                     amount: 1e18,
                     token: weth_(1),
@@ -1266,7 +1266,7 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
                     toAssetSymbol: "ETH"
                 })
             ),
-            "action context encoded from WrapActionContext"
+            "action context encoded from WrapOrUnwrapActionContext"
         );
         assertEq(result.actions[1].chainId, 1, "operation is on chainid 1");
         assertEq(result.actions[1].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
@@ -1380,7 +1380,7 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         assertEq(
             result.actions[0].actionContext,
             abi.encode(
-                Actions.WrapActionContext({
+                Actions.WrapOrUnwrapActionContext({
                     chainId: 1,
                     amount: 0.75e18,
                     token: eth_(),
@@ -1388,7 +1388,7 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
                     toAssetSymbol: "WETH"
                 })
             ),
-            "action context encoded from WrapActionContext"
+            "action context encoded from WrapOrUnwrapActionContext"
         );
         assertEq(result.actions[1].chainId, 1, "operation is on chainid 1");
         assertEq(result.actions[1].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");

--- a/test/builder/QuarkBuilderTransfer.t.sol
+++ b/test/builder/QuarkBuilderTransfer.t.sol
@@ -982,7 +982,7 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         assertEq(
             result.actions[0].actionContext,
             abi.encode(
-                Actions.WrappingActionContext({
+                Actions.WrapActionContext({
                     chainId: 1,
                     amount: 0.5e18,
                     token: weth_(1),
@@ -990,7 +990,7 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
                     toAssetSymbol: "ETH"
                 })
             ),
-            "action context encoded from WrappingActionContext"
+            "action context encoded from WrapActionContext"
         );
         assertEq(result.actions[1].chainId, 1, "operation is on chainid 1");
         assertEq(result.actions[1].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
@@ -1119,7 +1119,7 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         assertEq(
             result.actions[0].actionContext,
             abi.encode(
-                Actions.WrappingActionContext({
+                Actions.WrapActionContext({
                     chainId: 1,
                     amount: 0.5e18,
                     token: weth_(1),
@@ -1127,7 +1127,7 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
                     toAssetSymbol: "ETH"
                 })
             ),
-            "action context encoded from WrappingActionContext"
+            "action context encoded from WrapActionContext"
         );
         assertEq(result.actions[1].chainId, 1, "operation is on chainid 1");
         assertEq(result.actions[1].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
@@ -1258,7 +1258,7 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         assertEq(
             result.actions[0].actionContext,
             abi.encode(
-                Actions.WrappingActionContext({
+                Actions.WrapActionContext({
                     chainId: 1,
                     amount: 1e18,
                     token: weth_(1),
@@ -1266,7 +1266,7 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
                     toAssetSymbol: "ETH"
                 })
             ),
-            "action context encoded from WrappingActionContext"
+            "action context encoded from WrapActionContext"
         );
         assertEq(result.actions[1].chainId, 1, "operation is on chainid 1");
         assertEq(result.actions[1].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
@@ -1380,7 +1380,7 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         assertEq(
             result.actions[0].actionContext,
             abi.encode(
-                Actions.WrappingActionContext({
+                Actions.WrapActionContext({
                     chainId: 1,
                     amount: 0.75e18,
                     token: eth_(),
@@ -1388,7 +1388,7 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
                     toAssetSymbol: "WETH"
                 })
             ),
-            "action context encoded from WrappingActionContext"
+            "action context encoded from WrapActionContext"
         );
         assertEq(result.actions[1].chainId, 1, "operation is on chainid 1");
         assertEq(result.actions[1].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");

--- a/test/builder/lib/QuarkBuilderTest.sol
+++ b/test/builder/lib/QuarkBuilderTest.sol
@@ -13,6 +13,8 @@ contract QuarkBuilderTest {
     address constant USDC_8453 = 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913;
     address constant USDT_1 = 0xdAC17F958D2ee523a2206206994597C13D831ec7;
     address constant USDT_8453 = 0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2;
+    address constant WETH_1 = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+    address constant WETH_8453 = 0x4200000000000000000000000000000000000006;
     // Random address for mock assets in random unsupported chain
     address constant USDC_7777 = 0x8D89c5CaA76592e30e0410B9e68C0f235c62B312;
     address constant USDT_7777 = address(0xDEADBEEF);
@@ -124,6 +126,16 @@ contract QuarkBuilderTest {
         if (chainId == 8453) return USDT_8453;
         if (chainId == 7777) return USDT_7777; // Mock with random chain's USDT
         revert("no mock usdt for that chain id bye");
+    }
+
+    function eth_() internal pure returns (address) {
+        return 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+    }
+
+    function weth_(uint256 chainId) internal pure returns (address) {
+        if (chainId == 1) return WETH_1;
+        if (chainId == 8453) return WETH_8453;
+        revert("no mock weth for that chain id bye");
     }
 
     function quarkStates_(address account, uint96 nextNonce) internal pure returns (Accounts.QuarkState[] memory) {

--- a/test/lib/IStETH.sol
+++ b/test/lib/IStETH.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity 0.8.23;
+
+interface IStETH {
+    function submit(address _referral) external payable returns (uint256);
+}


### PR DESCRIPTION
Auto wrap/unwrap  get way more complicated than it looks. 

- Assuming wrap/unwrap at source chain before bridging  (So always bridge the intent asset and never consider bridging counterpart assets then wrap/unwrap at destination chain.)
- Assuming ratio of wrap:unwrap is 1:1  (This will be problematic on stETH and wstETH.  Since we need on-chain data to know the latest pricefeed data between stETH and wstETH as wstETH values grows over stETH rebasing #


Some key behaviors to note: 
- When user transfer X ETH, the builder will first see if the current chain has enough of WETH+ETH to cover the request before going to search for bridging options.
- When usre transfer X Token that is high enough to require brdging and the token has wrapper in both dstChain and srcChains.  The builder will start searching other chain to bridge.  And in each srcChain it will try to wrap/unwrap the token into the bridging token and maximize the bridge token from one chain. So if needed the builder will wrap/unwrap the token at srcChain and accrue with the intent token in srcChain then bridge to dstChain in one batch.
-  When user request to send token that requires auto wrap/unwrap the token while the counterpart token is the payment token and user opts to pay with payment token. The builder shall account the balance difference and substract that from available to wrap/unwrap computation.
- If wrapper is not existing on the chain, the builder will omit the counterpart tokens completely. 