### PR TITLE
Add fee info to swap action context

### DIFF
--- a/src/builder/QuarkBuilder.sol
+++ b/src/builder/QuarkBuilder.sol
@@ -733,7 +733,7 @@ contract QuarkBuilder {
         });
     }
 
-    struct MatchaSwapIntent {
+    struct ZeroExSwapIntent {
         uint256 chainId;
         address entryPoint;
         bytes swapData;
@@ -741,12 +741,14 @@ contract QuarkBuilder {
         uint256 sellAmount;
         address buyToken;
         uint256 expectedBuyAmount;
+        address feeToken;
+        uint256 feeAmount;
         address sender;
         uint256 blockTimestamp;
     }
 
     function swap(
-        MatchaSwapIntent memory swapIntent,
+        ZeroExSwapIntent memory swapIntent,
         Accounts.ChainAccounts[] memory chainAccountsList,
         PaymentInfo.Payment memory payment
     ) external pure returns (BuilderResult memory) {
@@ -759,6 +761,8 @@ contract QuarkBuilder {
             Accounts.findAssetPositions(swapIntent.sellToken, swapIntent.chainId, chainAccountsList).symbol;
         string memory buyAssetSymbol =
             Accounts.findAssetPositions(swapIntent.buyToken, swapIntent.chainId, chainAccountsList).symbol;
+        string memory feeAssetSymbol =
+            Accounts.findAssetPositions(swapIntent.feeToken, swapIntent.chainId, chainAccountsList).symbol;
         assertFundsAvailable(swapIntent.chainId, sellAssetSymbol, swapIntent.sellAmount, chainAccountsList, payment);
 
         // TODO: When should we use quotecall?
@@ -838,8 +842,8 @@ contract QuarkBuilder {
         );
 
         // Then, swap `amount` of `assetSymbol` to `recipient`
-        (IQuarkWallet.QuarkOperation memory operation, Actions.Action memory action) = Actions.matchaSwap(
-            Actions.MatchaSwap({
+        (IQuarkWallet.QuarkOperation memory operation, Actions.Action memory action) = Actions.zeroExSwap(
+            Actions.ZeroExSwap({
                 chainAccountsList: chainAccountsList,
                 entryPoint: swapIntent.entryPoint,
                 swapData: swapIntent.swapData,
@@ -849,6 +853,9 @@ contract QuarkBuilder {
                 buyToken: swapIntent.buyToken,
                 buyAssetSymbol: buyAssetSymbol,
                 expectedBuyAmount: swapIntent.expectedBuyAmount,
+                feeToken: swapIntent.feeToken,
+                feeAssetSymbol: feeAssetSymbol,
+                feeAmount: swapIntent.feeAmount,
                 chainId: swapIntent.chainId,
                 sender: swapIntent.sender,
                 blockTimestamp: swapIntent.blockTimestamp

--- a/src/builder/QuarkBuilder.sol
+++ b/src/builder/QuarkBuilder.sol
@@ -19,7 +19,7 @@ import {List} from "./List.sol";
 contract QuarkBuilder {
     /* ===== Constants ===== */
 
-    string constant VERSION = "0.0.1";
+    string constant VERSION = "0.0.2";
 
     /* ===== Custom Errors ===== */
 

--- a/test/builder/QuarkBuilderSwap.t.sol
+++ b/test/builder/QuarkBuilderSwap.t.sol
@@ -509,7 +509,7 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
                     feeAmount: 10,
                     feeAssetSymbol: "WETH",
                     feeToken: WETH_8453,
-                    feeTokenPrice: 3000e8,
+                    feeTokenPrice: WETH_PRICE,
                     inputToken: USDC_8453,
                     inputTokenPrice: USDC_PRICE,
                     inputAssetSymbol: "USDC",

--- a/test/builder/QuarkBuilderSwap.t.sol
+++ b/test/builder/QuarkBuilderSwap.t.sol
@@ -21,7 +21,6 @@ import {PaycallWrapper} from "src/builder/PaycallWrapper.sol";
 import {PaymentInfo} from "src/builder/PaymentInfo.sol";
 
 contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
-    uint256 constant BLOCK_TIMESTAMP = 123_456_789;
     address constant ZERO_EX_ENTRY_POINT = 0xDef1C0ded9bec7F1a1670819833240f027b25EfF;
     bytes constant ZERO_EX_SWAP_DATA = hex"abcdef";
 

--- a/test/builder/QuarkBuilderSwap.t.sol
+++ b/test/builder/QuarkBuilderSwap.t.sol
@@ -779,7 +779,7 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
                     feeAmount: 10,
                     feeAssetSymbol: "WETH",
                     feeToken: WETH_8453,
-                    feeTokenPrice: 3000e8,
+                    feeTokenPrice: WETH_PRICE,
                     inputToken: USDT_8453,
                     inputTokenPrice: USDT_PRICE,
                     inputAssetSymbol: "USDT",

--- a/test/builder/QuarkBuilderSwap.t.sol
+++ b/test/builder/QuarkBuilderSwap.t.sol
@@ -197,7 +197,7 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
                     feeAmount: 10,
                     feeAssetSymbol: "WETH",
                     feeToken: WETH_1,
-                    feeTokenPrice: 3000e8,
+                    feeTokenPrice: WETH_PRICE,
                     inputToken: USDC_1,
                     inputTokenPrice: USDC_PRICE,
                     inputAssetSymbol: "USDC",

--- a/test/builder/QuarkBuilderSwap.t.sol
+++ b/test/builder/QuarkBuilderSwap.t.sol
@@ -21,8 +21,9 @@ import {PaycallWrapper} from "src/builder/PaycallWrapper.sol";
 import {PaymentInfo} from "src/builder/PaymentInfo.sol";
 
 contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
-    address constant MATCHA_ENTRY_POINT = 0xDef1C0ded9bec7F1a1670819833240f027b25EfF;
-    bytes constant MATCHA_SWAP_DATA = hex"abcdef";
+    uint256 constant BLOCK_TIMESTAMP = 123_456_789;
+    address constant ZERO_EX_ENTRY_POINT = 0xDef1C0ded9bec7F1a1670819833240f027b25EfF;
+    bytes constant ZERO_EX_SWAP_DATA = hex"abcdef";
 
     function buyUsdc_(
         uint256 chainId,
@@ -53,12 +54,12 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
         uint256 expectedBuyAmount,
         address sender,
         uint256 blockTimestamp
-    ) internal pure returns (QuarkBuilder.MatchaSwapIntent memory) {
+    ) internal pure returns (QuarkBuilder.ZeroExSwapIntent memory) {
         address weth = weth_(chainId);
-        return matchaSwap_(
+        return zeroExSwap_(
             chainId,
-            MATCHA_ENTRY_POINT,
-            MATCHA_SWAP_DATA,
+            ZERO_EX_ENTRY_POINT,
+            ZERO_EX_SWAP_DATA,
             sellToken,
             sellAmount,
             weth,
@@ -68,7 +69,7 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
         );
     }
 
-    function matchaSwap_(
+    function zeroExSwap_(
         uint256 chainId,
         address entryPoint,
         bytes memory swapData,
@@ -78,8 +79,8 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
         uint256 expectedBuyAmount,
         address sender,
         uint256 blockTimestamp
-    ) internal pure returns (QuarkBuilder.MatchaSwapIntent memory) {
-        return QuarkBuilder.MatchaSwapIntent({
+    ) internal pure returns (QuarkBuilder.ZeroExSwapIntent memory) {
+        return QuarkBuilder.ZeroExSwapIntent({
             chainId: chainId,
             entryPoint: entryPoint,
             swapData: swapData,
@@ -87,6 +88,8 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
             sellAmount: sellAmount,
             buyToken: buyToken,
             expectedBuyAmount: expectedBuyAmount,
+            feeToken: buyToken,
+            feeAmount: 10,
             sender: sender,
             blockTimestamp: blockTimestamp
         });
@@ -172,8 +175,8 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
         );
         assertEq(
             result.quarkOperations[0].scriptCalldata,
-            abi.encodeCall(ApproveAndSwap.run, (MATCHA_ENTRY_POINT, USDC_1, 3000e6, WETH_1, 1e18, MATCHA_SWAP_DATA)),
-            "calldata is ApproveAndSwap.run(MATCHA_ENTRY_POINT, USDC_1, 3500e6, WETH_1, 1e18, MATCHA_SWAP_DATA);"
+            abi.encodeCall(ApproveAndSwap.run, (ZERO_EX_ENTRY_POINT, USDC_1, 3000e6, WETH_1, 1e18, ZERO_EX_SWAP_DATA)),
+            "calldata is ApproveAndSwap.run(ZERO_EX_ENTRY_POINT, USDC_1, 3500e6, WETH_1, 1e18, ZERO_EX_SWAP_DATA);"
         );
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 3 days, "expiry is current blockTimestamp + 3 days"
@@ -192,6 +195,10 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
             abi.encode(
                 Actions.SwapActionContext({
                     chainId: 1,
+                    feeAmount: 10,
+                    feeAssetSymbol: "WETH",
+                    feeToken: WETH_1,
+                    feeTokenPrice: 3000e8,
                     inputToken: USDC_1,
                     inputTokenPrice: USDC_PRICE,
                     inputAssetSymbol: "USDC",
@@ -340,11 +347,11 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
                 Paycall.run.selector,
                 approveAndSwapAddress,
                 abi.encodeWithSelector(
-                    ApproveAndSwap.run.selector, MATCHA_ENTRY_POINT, USDC_1, 3000e6, WETH_1, 1e18, MATCHA_SWAP_DATA
+                    ApproveAndSwap.run.selector, ZERO_EX_ENTRY_POINT, USDC_1, 3000e6, WETH_1, 1e18, ZERO_EX_SWAP_DATA
                 ),
                 5e6
             ),
-            "calldata is Paycall.run(ApproveAndSwap.run(MATCHA_ENTRY_POINT, USDC_1, 3500e6, WETH_1, 1e18, MATCHA_SWAP_DATA), 5e6);"
+            "calldata is Paycall.run(ApproveAndSwap.run(ZERO_EX_ENTRY_POINT, USDC_1, 3500e6, WETH_1, 1e18, ZERO_EX_SWAP_DATA), 5e6);"
         );
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 3 days, "expiry is current blockTimestamp + 3 days"
@@ -362,6 +369,10 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
             abi.encode(
                 Actions.SwapActionContext({
                     chainId: 1,
+                    feeAmount: 10,
+                    feeAssetSymbol: "WETH",
+                    feeToken: WETH_1,
+                    feeTokenPrice: 3000e8,
                     inputToken: USDC_1,
                     inputTokenPrice: USDC_PRICE,
                     inputAssetSymbol: "USDC",
@@ -453,9 +464,9 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
         assertEq(
             result.quarkOperations[1].scriptCalldata,
             abi.encodeCall(
-                ApproveAndSwap.run, (MATCHA_ENTRY_POINT, USDC_8453, 3000e6, WETH_8453, 1e18, MATCHA_SWAP_DATA)
+                ApproveAndSwap.run, (ZERO_EX_ENTRY_POINT, USDC_8453, 3000e6, WETH_8453, 1e18, ZERO_EX_SWAP_DATA)
             ),
-            "calldata is ApproveAndSwap.run(MATCHA_ENTRY_POINT, USDC_8453, 3500e6, WETH_8453, 1e18, MATCHA_SWAP_DATA);"
+            "calldata is ApproveAndSwap.run(ZERO_EX_ENTRY_POINT, USDC_8453, 3500e6, WETH_8453, 1e18, ZERO_EX_SWAP_DATA);"
         );
         assertEq(
             result.quarkOperations[1].expiry, BLOCK_TIMESTAMP + 3 days, "expiry is current blockTimestamp + 3 days"
@@ -496,6 +507,10 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
             abi.encode(
                 Actions.SwapActionContext({
                     chainId: 8453,
+                    feeAmount: 10,
+                    feeAssetSymbol: "WETH",
+                    feeToken: WETH_8453,
+                    feeTokenPrice: 3000e8,
                     inputToken: USDC_8453,
                     inputTokenPrice: USDC_PRICE,
                     inputAssetSymbol: "USDC",
@@ -577,16 +592,16 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
                 approveAndSwapAddress,
                 abi.encodeWithSelector(
                     ApproveAndSwap.run.selector,
-                    MATCHA_ENTRY_POINT,
+                    ZERO_EX_ENTRY_POINT,
                     USDC_8453,
                     3000e6,
                     WETH_8453,
                     1e18,
-                    MATCHA_SWAP_DATA
+                    ZERO_EX_SWAP_DATA
                 ),
                 1e6
             ),
-            "calldata is Paycall.run(ApproveAndSwap.run(MATCHA_ENTRY_POINT, USDC_8453, 3500e6, WETH_8453, 1e18, MATCHA_SWAP_DATA), 5e6);"
+            "calldata is Paycall.run(ApproveAndSwap.run(ZERO_EX_ENTRY_POINT, USDC_8453, 3500e6, WETH_8453, 1e18, ZERO_EX_SWAP_DATA), 5e6);"
         );
         assertEq(
             result.quarkOperations[1].expiry, BLOCK_TIMESTAMP + 3 days, "expiry is current blockTimestamp + 3 days"
@@ -627,6 +642,10 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
             abi.encode(
                 Actions.SwapActionContext({
                     chainId: 8453,
+                    feeAmount: 10,
+                    feeAssetSymbol: "WETH",
+                    feeToken: WETH_8453,
+                    feeTokenPrice: 3000e8,
                     inputToken: USDC_8453,
                     inputTokenPrice: USDC_PRICE,
                     inputAssetSymbol: "USDC",
@@ -703,16 +722,16 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
                 approveAndSwapAddress,
                 abi.encodeWithSelector(
                     ApproveAndSwap.run.selector,
-                    MATCHA_ENTRY_POINT,
+                    ZERO_EX_ENTRY_POINT,
                     USDT_8453,
                     3000e6,
                     WETH_8453,
                     1e18,
-                    MATCHA_SWAP_DATA
+                    ZERO_EX_SWAP_DATA
                 ),
                 3500e6
             ),
-            "calldata is Paycall.run(ApproveAndSwap.run(MATCHA_ENTRY_POINT, USDT_8453, 3500e6, WETH_8453, 1e18, MATCHA_SWAP_DATA), 3500e6);"
+            "calldata is Paycall.run(ApproveAndSwap.run(ZERO_EX_ENTRY_POINT, USDT_8453, 3500e6, WETH_8453, 1e18, ZERO_EX_SWAP_DATA), 3500e6);"
         );
         assertEq(
             result.quarkOperations[1].scriptAddress,
@@ -758,6 +777,10 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
             abi.encode(
                 Actions.SwapActionContext({
                     chainId: 8453,
+                    feeAmount: 10,
+                    feeAssetSymbol: "WETH",
+                    feeToken: WETH_8453,
+                    feeTokenPrice: 3000e8,
                     inputToken: USDT_8453,
                     inputTokenPrice: USDT_PRICE,
                     inputAssetSymbol: "USDT",

--- a/test/builder/QuarkBuilderSwap.t.sol
+++ b/test/builder/QuarkBuilderSwap.t.sol
@@ -371,7 +371,7 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
                     feeAmount: 10,
                     feeAssetSymbol: "WETH",
                     feeToken: WETH_1,
-                    feeTokenPrice: 3000e8,
+                    feeTokenPrice: WETH_PRICE,
                     inputToken: USDC_1,
                     inputTokenPrice: USDC_PRICE,
                     inputAssetSymbol: "USDC",

--- a/test/builder/QuarkBuilderSwap.t.sol
+++ b/test/builder/QuarkBuilderSwap.t.sol
@@ -31,12 +31,12 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
         uint256 expectedBuyAmount,
         address sender,
         uint256 blockTimestamp
-    ) internal pure returns (QuarkBuilder.MatchaSwapIntent memory) {
+    ) internal pure returns (QuarkBuilder.ZeroExSwapIntent memory) {
         address usdc = usdc_(chainId);
-        return matchaSwap_(
+        return zeroExSwap_(
             chainId,
-            MATCHA_ENTRY_POINT,
-            MATCHA_SWAP_DATA,
+            ZERO_EX_ENTRY_POINT,
+            ZERO_EX_SWAP_DATA,
             sellToken,
             sellAmount,
             usdc,
@@ -274,11 +274,11 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
         callDatas[0] =
             abi.encodeWithSelector(WrapperActions.wrapETH.selector, 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, 1e18);
         callDatas[1] =
-            abi.encodeCall(ApproveAndSwap.run, (MATCHA_ENTRY_POINT, WETH_1, 1e18, USDC_1, 3000e6, MATCHA_SWAP_DATA));
+            abi.encodeCall(ApproveAndSwap.run, (ZERO_EX_ENTRY_POINT, WETH_1, 1e18, USDC_1, 3000e6, ZERO_EX_SWAP_DATA));
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-            "calldata is Multicall.run([wrapperActionsAddress, approveAndSwapAddress], [WrapperActions.wrapWETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, 1e18), ApproveAndSwap.run (MATCHA_ENTRY_POINT, WETH_1, 1e18, USDC_1, 3000e6,  MATCHA_SWAP_DATA)]);"
+            "calldata is Multicall.run([wrapperActionsAddress, approveAndSwapAddress], [WrapperActions.wrapWETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, 1e18), ApproveAndSwap.run (ZERO_EX_ENTRY_POINT, WETH_1, 1e18, USDC_1, 3000e6,  ZERO_EX_SWAP_DATA)]);"
         );
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 3 days, "expiry is current blockTimestamp + 3 days"
@@ -297,6 +297,10 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
             abi.encode(
                 Actions.SwapActionContext({
                     chainId: 1,
+                    feeAmount: 10,
+                    feeAssetSymbol: "USDC",
+                    feeToken: USDC_1,
+                    feeTokenPrice: USDC_PRICE,
                     inputToken: WETH_1,
                     inputTokenPrice: WETH_PRICE,
                     inputAssetSymbol: "WETH",

--- a/test/builder/QuarkBuilderSwap.t.sol
+++ b/test/builder/QuarkBuilderSwap.t.sol
@@ -644,7 +644,7 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
                     feeAmount: 10,
                     feeAssetSymbol: "WETH",
                     feeToken: WETH_8453,
-                    feeTokenPrice: 3000e8,
+                    feeTokenPrice: WETH_PRICE,
                     inputToken: USDC_8453,
                     inputTokenPrice: USDC_PRICE,
                     inputAssetSymbol: "USDC",


### PR DESCRIPTION
We add information about the fees paid for a swap to the swap action context. We also rename any references of Matcha to ZeroEx, since ZeroEx is the underlying protocol where the swaps are getting routed through.