### PR TITLE
CometWithdraw max

### DIFF
--- a/src/builder/Accounts.sol
+++ b/src/builder/Accounts.sol
@@ -12,7 +12,7 @@ library Accounts {
         uint256 chainId;
         QuarkState[] quarkStates;
         AssetPositions[] assetPositionsList;
-        CometPosition[] cometPositions;
+        CometPositions[] cometPositions;
     }
 
     // We map this to the Portfolio data structure that the client will already have.
@@ -38,7 +38,7 @@ library Accounts {
         uint256 balance;
     }
 
-    struct CometPosition {
+    struct CometPositions {
         address comet;
         CometBasePosition basePosition;
         CometCollateralPosition[] collaterals;
@@ -69,10 +69,10 @@ library Accounts {
         }
     }
 
-    function findCometPosition(uint256 chainId, address comet, ChainAccounts[] memory chainAccountsList)
+    function findCometPositions(uint256 chainId, address comet, ChainAccounts[] memory chainAccountsList)
         internal
         pure
-        returns (CometPosition memory found)
+        returns (CometPositions memory found)
     {
         ChainAccounts memory chainAccounts = findChainAccounts(chainId, chainAccountsList);
         for (uint256 i = 0; i < chainAccounts.cometPositions.length; ++i) {

--- a/src/builder/Accounts.sol
+++ b/src/builder/Accounts.sol
@@ -41,7 +41,7 @@ library Accounts {
     struct CometPositions {
         address comet;
         CometBasePosition basePosition;
-        CometCollateralPosition[] collaterals;
+        CometCollateralPosition[] collateralPositions;
     }
 
     struct CometBasePosition {

--- a/src/builder/Accounts.sol
+++ b/src/builder/Accounts.sol
@@ -12,6 +12,7 @@ library Accounts {
         uint256 chainId;
         QuarkState[] quarkStates;
         AssetPositions[] assetPositionsList;
+        CometPosition[] cometPositions;
     }
 
     // We map this to the Portfolio data structure that the client will already have.
@@ -37,6 +38,25 @@ library Accounts {
         uint256 balance;
     }
 
+    struct CometPosition {
+        address comet;
+        CometBasePosition basePosition;
+        CometCollateralPosition[] collaterals;
+    }
+
+    struct CometBasePosition {
+        address asset;
+        address[] accounts;
+        uint256[] borrowed;
+        uint256[] supplied;
+    }
+
+    struct CometCollateralPosition {
+        address asset;
+        address[] accounts;
+        uint256[] balances;
+    }
+
     function findChainAccounts(uint256 chainId, ChainAccounts[] memory chainAccountsList)
         internal
         pure
@@ -45,6 +65,19 @@ library Accounts {
         for (uint256 i = 0; i < chainAccountsList.length; ++i) {
             if (chainAccountsList[i].chainId == chainId) {
                 return found = chainAccountsList[i];
+            }
+        }
+    }
+
+    function findCometPosition(uint256 chainId, address comet, ChainAccounts[] memory chainAccountsList)
+        internal
+        pure
+        returns (CometPosition memory found)
+    {
+        ChainAccounts memory chainAccounts = findChainAccounts(chainId, chainAccountsList);
+        for (uint256 i = 0; i < chainAccounts.cometPositions.length; ++i) {
+            if (chainAccounts.cometPositions[i].comet == comet) {
+                return found = chainAccounts.cometPositions[i];
             }
         }
     }

--- a/src/builder/Actions.sol
+++ b/src/builder/Actions.sol
@@ -698,8 +698,7 @@ library Actions {
 
     function cometWithdrawAsset(
         CometWithdraw memory cometWithdraw,
-        PaymentInfo.Payment memory payment,
-        bool useQuotecall
+        PaymentInfo.Payment memory payment
     ) internal pure returns (IQuarkWallet.QuarkOperation memory, Action memory) {
         bytes[] memory scriptSources = new bytes[](1);
         scriptSources[0] = type(CometWithdrawActions).creationCode;
@@ -744,7 +743,7 @@ library Actions {
             quarkAccount: cometWithdraw.withdrawer,
             actionType: ACTION_TYPE_WITHDRAW,
             actionContext: abi.encode(cometWithdrawActionContext),
-            paymentMethod: PaymentInfo.paymentMethodForPayment(payment, useQuotecall),
+            paymentMethod: PaymentInfo.paymentMethodForPayment(payment, false),
             // Null address for OFFCHAIN payment.
             paymentToken: payment.isToken
                 ? PaymentInfo.knownToken(payment.currency, cometWithdraw.chainId).token

--- a/src/builder/Actions.sol
+++ b/src/builder/Actions.sol
@@ -23,10 +23,6 @@ import {List} from "./List.sol";
 
 library Actions {
     /* ===== Constants ===== */
-    string constant PAYMENT_METHOD_OFFCHAIN = "OFFCHAIN";
-    string constant PAYMENT_METHOD_PAYCALL = "PAY_CALL";
-    string constant PAYMENT_METHOD_QUOTECALL = "QUOTE_CALL";
-
     string constant ACTION_TYPE_BORROW = "BORROW";
     string constant ACTION_TYPE_BRIDGE = "BRIDGE";
     string constant ACTION_TYPE_CLAIM_REWARDS = "CLAIM_REWARDS";
@@ -145,7 +141,7 @@ library Actions {
         address quarkAccount;
         string actionType;
         bytes actionContext;
-        // One of the PAYMENT_METHOD_* constants.
+        // One of the PaymentInfo.PAYMENT_METHOD_* constants.
         string paymentMethod;
         // Address of payment token on chainId.
         // Null address if the payment method was OFFCHAIN.
@@ -458,20 +454,12 @@ library Actions {
             bridgeType: BRIDGE_TYPE_CCTP
         });
 
-        string memory paymentMethod;
-        if (payment.isToken) {
-            // To pay with token, it has to be a paycall or quotecall.
-            paymentMethod = useQuotecall ? PAYMENT_METHOD_QUOTECALL : PAYMENT_METHOD_PAYCALL;
-        } else {
-            paymentMethod = PAYMENT_METHOD_OFFCHAIN;
-        }
-
         Action memory action = Actions.Action({
             chainId: bridge.srcChainId,
             quarkAccount: bridge.sender,
             actionType: ACTION_TYPE_BRIDGE,
             actionContext: abi.encode(bridgeActionContext),
-            paymentMethod: paymentMethod,
+            paymentMethod: PaymentInfo.paymentMethodForPayment(payment, useQuotecall),
             // Null address for OFFCHAIN payment.
             paymentToken: payment.isToken ? PaymentInfo.knownToken(payment.currency, bridge.srcChainId).token : address(0),
             paymentTokenSymbol: payment.currency,
@@ -556,7 +544,7 @@ library Actions {
             quarkAccount: borrowInput.borrower,
             actionType: ACTION_TYPE_BORROW,
             actionContext: abi.encode(repayActionContext),
-            paymentMethod: payment.isToken ? PAYMENT_METHOD_PAYCALL : PAYMENT_METHOD_OFFCHAIN,
+            paymentMethod: PaymentInfo.paymentMethodForPayment(payment, false),
             // Null address for OFFCHAIN payment.
             paymentToken: payment.isToken ? PaymentInfo.knownToken(payment.currency, borrowInput.chainId).token : address(0),
             paymentTokenSymbol: payment.currency,
@@ -641,7 +629,7 @@ library Actions {
             quarkAccount: repayInput.repayer,
             actionType: ACTION_TYPE_REPAY,
             actionContext: abi.encode(repayActionContext),
-            paymentMethod: payment.isToken ? PAYMENT_METHOD_PAYCALL : PAYMENT_METHOD_OFFCHAIN,
+            paymentMethod: PaymentInfo.paymentMethodForPayment(payment, false),
             // Null address for OFFCHAIN payment.
             paymentToken: payment.isToken ? PaymentInfo.knownToken(payment.currency, repayInput.chainId).token : address(0),
             paymentTokenSymbol: payment.currency,
@@ -698,7 +686,7 @@ library Actions {
             quarkAccount: cometSupply.sender,
             actionType: ACTION_TYPE_SUPPLY,
             actionContext: abi.encode(cometSupplyActionContext),
-            paymentMethod: payment.isToken ? PAYMENT_METHOD_PAYCALL : PAYMENT_METHOD_OFFCHAIN,
+            paymentMethod: PaymentInfo.paymentMethodForPayment(payment, false),
             // Null address for OFFCHAIN payment.
             paymentToken: payment.isToken ? PaymentInfo.knownToken(payment.currency, cometSupply.chainId).token : address(0),
             paymentTokenSymbol: payment.currency,
@@ -756,7 +744,7 @@ library Actions {
             quarkAccount: cometWithdraw.withdrawer,
             actionType: ACTION_TYPE_WITHDRAW,
             actionContext: abi.encode(cometWithdrawActionContext),
-            paymentMethod: paymentMethodForPayment(payment, useQuotecall),
+            paymentMethod: PaymentInfo.paymentMethodForPayment(payment, useQuotecall),
             // Null address for OFFCHAIN payment.
             paymentToken: payment.isToken
                 ? PaymentInfo.knownToken(payment.currency, cometWithdraw.chainId).token
@@ -820,7 +808,7 @@ library Actions {
             quarkAccount: transfer.sender,
             actionType: ACTION_TYPE_TRANSFER,
             actionContext: abi.encode(transferActionContext),
-            paymentMethod: paymentMethodForPayment(payment, useQuotecall),
+            paymentMethod: PaymentInfo.paymentMethodForPayment(payment, useQuotecall),
             // Null address for OFFCHAIN payment.
             paymentToken: payment.isToken ? PaymentInfo.knownToken(payment.currency, transfer.chainId).token : address(0),
             paymentTokenSymbol: payment.currency,
@@ -828,20 +816,6 @@ library Actions {
         });
 
         return (quarkOperation, action);
-    }
-
-    function paymentMethodForPayment(PaymentInfo.Payment memory payment, bool useQuotecall)
-        internal
-        pure
-        returns (string memory)
-    {
-        if (payment.isToken && useQuotecall) {
-            return PAYMENT_METHOD_QUOTECALL;
-        } else if (payment.isToken && !useQuotecall) {
-            return PAYMENT_METHOD_PAYCALL;
-        } else {
-            return PAYMENT_METHOD_OFFCHAIN;
-        }
     }
 
     function wrapOrUnwrapAsset(
@@ -879,14 +853,6 @@ library Actions {
             toAssetSymbol: TokenWrapper.getWrapperCounterpartSymbol(wrapOrUnwrap.chainId, assetPositions.symbol)
         });
 
-        string memory paymentMethod;
-        if (payment.isToken) {
-            // To pay with token, it has to be a paycall or quotecall.
-            paymentMethod = useQuotecall ? PAYMENT_METHOD_QUOTECALL : PAYMENT_METHOD_PAYCALL;
-        } else {
-            paymentMethod = PAYMENT_METHOD_OFFCHAIN;
-        }
-
         Action memory action = Actions.Action({
             chainId: wrapOrUnwrap.chainId,
             quarkAccount: wrapOrUnwrap.sender,
@@ -894,7 +860,7 @@ library Actions {
                 ? ACTION_TYPE_UNWRAP
                 : ACTION_TYPE_WRAP,
             actionContext: abi.encode(wrapOrUnwrapActionContext),
-            paymentMethod: paymentMethod,
+            paymentMethod: PaymentInfo.paymentMethodForPayment(payment, useQuotecall),
             // Null address for OFFCHAIN payment.
             paymentToken: payment.isToken
                 ? PaymentInfo.knownToken(payment.currency, wrapOrUnwrap.chainId).token
@@ -963,20 +929,13 @@ library Actions {
             outputToken: swap.buyToken,
             outputTokenPrice: buyTokenAssetPositions.usdPrice
         });
-        string memory paymentMethod;
-        if (payment.isToken) {
-            // To pay with token, it has to be a paycall or quotecall.
-            paymentMethod = useQuotecall ? PAYMENT_METHOD_QUOTECALL : PAYMENT_METHOD_PAYCALL;
-        } else {
-            paymentMethod = PAYMENT_METHOD_OFFCHAIN;
-        }
 
         Action memory action = Actions.Action({
             chainId: swap.chainId,
             quarkAccount: swap.sender,
             actionType: ACTION_TYPE_SWAP,
             actionContext: abi.encode(swapActionContext),
-            paymentMethod: paymentMethod,
+            paymentMethod: PaymentInfo.paymentMethodForPayment(payment, useQuotecall),
             // Null address for OFFCHAIN payment.
             paymentToken: payment.isToken ? PaymentInfo.knownToken(payment.currency, swap.chainId).token : address(0),
             paymentTokenSymbol: payment.currency,

--- a/src/builder/Actions.sol
+++ b/src/builder/Actions.sol
@@ -696,10 +696,11 @@ library Actions {
         return (quarkOperation, action);
     }
 
-    function cometWithdrawAsset(
-        CometWithdraw memory cometWithdraw,
-        PaymentInfo.Payment memory payment
-    ) internal pure returns (IQuarkWallet.QuarkOperation memory, Action memory) {
+    function cometWithdrawAsset(CometWithdraw memory cometWithdraw, PaymentInfo.Payment memory payment)
+        internal
+        pure
+        returns (IQuarkWallet.QuarkOperation memory, Action memory)
+    {
         bytes[] memory scriptSources = new bytes[](1);
         scriptSources[0] = type(CometWithdrawActions).creationCode;
 

--- a/src/builder/PaymentInfo.sol
+++ b/src/builder/PaymentInfo.sol
@@ -4,6 +4,10 @@ pragma solidity ^0.8.23;
 import {Strings} from "./Strings.sol";
 
 library PaymentInfo {
+    string constant PAYMENT_METHOD_OFFCHAIN = "OFFCHAIN";
+    string constant PAYMENT_METHOD_PAYCALL = "PAY_CALL";
+    string constant PAYMENT_METHOD_QUOTECALL = "QUOTE_CALL";
+
     error NoKnownPaymentToken(uint256 chainId);
     error MaxCostMissingForChain(uint256 chainId);
 
@@ -75,5 +79,19 @@ library PaymentInfo {
             }
         }
         return false;
+    }
+
+    function paymentMethodForPayment(PaymentInfo.Payment memory payment, bool useQuotecall)
+        internal
+        pure
+        returns (string memory)
+    {
+        if (payment.isToken && useQuotecall) {
+            return PAYMENT_METHOD_QUOTECALL;
+        } else if (payment.isToken && !useQuotecall) {
+            return PAYMENT_METHOD_PAYCALL;
+        } else {
+            return PAYMENT_METHOD_OFFCHAIN;
+        }
     }
 }

--- a/src/builder/QuarkBuilder.sol
+++ b/src/builder/QuarkBuilder.sol
@@ -579,13 +579,13 @@ contract QuarkBuilder {
                     //
                     // assumes that a maxWithdraw is for the base asset, since
                     // you cannot maxWithdraw Collateral
-                    Accounts.CometPosition memory cometPosition = Accounts.findCometPosition(
+                    Accounts.CometPositions memory cometPositions = Accounts.findCometPositions(
                         cometWithdrawIntent.chainId, cometWithdrawIntent.comet, chainAccountsList
                     );
 
-                    for (uint256 i = 0; i < cometPosition.basePosition.accounts.length; ++i) {
-                        if (cometPosition.basePosition.accounts[i] == cometWithdrawIntent.withdrawer) {
-                            supplementalPaymentTokenBalance += cometPosition.basePosition.supplied[i];
+                    for (uint256 i = 0; i < cometPositions.basePosition.accounts.length; ++i) {
+                        if (cometPositions.basePosition.accounts[i] == cometWithdrawIntent.withdrawer) {
+                            supplementalPaymentTokenBalance += cometPositions.basePosition.supplied[i];
                         }
                     }
                 } else {

--- a/src/builder/QuarkBuilder.sol
+++ b/src/builder/QuarkBuilder.sol
@@ -509,7 +509,7 @@ contract QuarkBuilder {
         // XXX confirm that you actually have the amount to withdraw
 
         bool isMaxWithdraw = cometWithdrawIntent.amount == type(uint256).max;
-        bool useQuotecall = payment.isToken && isMaxWithdraw;
+        bool useQuotecall = false; // never use Quotecall
         List.DynamicArray memory actions = List.newList();
         List.DynamicArray memory quarkOperations = List.newList();
 
@@ -559,8 +559,7 @@ contract QuarkBuilder {
                 withdrawer: cometWithdrawIntent.withdrawer,
                 blockTimestamp: cometWithdrawIntent.blockTimestamp
             }),
-            payment,
-            useQuotecall
+            payment
         );
         List.addAction(actions, cometWithdrawAction);
         List.addQuarkOperation(quarkOperations, cometWithdrawQuarkOperation);

--- a/test/builder/QuarkBuilderCometBorrow.t.sol
+++ b/test/builder/QuarkBuilderCometBorrow.t.sol
@@ -206,15 +206,17 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
             chainId: 1,
             account: address(0xa11ce),
             nextNonce: 12,
-            assetSymbols: stringArray("USDC", "ETH", "LINK", "WETH"),
-            assetBalances: uintArray(0, 10e18, 0, 0) // user has 10 ETH
+            assetSymbols: Arrays.stringArray("USDC", "ETH", "LINK", "WETH"),
+            assetBalances: Arrays.uintArray(0, 10e18, 0, 0), // user has 10 ETH
+            cometPortfolios: emptyCometPortfolios_()
         });
         chainPortfolios[1] = ChainPortfolio({
             chainId: 8453,
             account: address(0xb0b),
             nextNonce: 2,
-            assetSymbols: stringArray("USDC", "ETH", "LINK", "WETH"),
-            assetBalances: uintArray(0, 0, 0, 0)
+            assetSymbols: Arrays.stringArray("USDC", "ETH", "LINK", "WETH"),
+            assetBalances: Arrays.uintArray(0, 0, 0, 0),
+            cometPortfolios: emptyCometPortfolios_()
         });
 
         QuarkBuilder builder = new QuarkBuilder();
@@ -250,7 +252,7 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
         callDatas[0] =
             abi.encodeWithSelector(WrapperActions.wrapETH.selector, 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, 1e18);
         callDatas[1] = abi.encodeCall(
-            CometSupplyMultipleAssetsAndBorrow.run, (COMET_1, collateralTokens, collateralAmounts, usdc_(1), 1e6)
+            CometSupplyMultipleAssetsAndBorrow.run, (cometUsdc_(1), collateralTokens, collateralAmounts, usdc_(1), 1e6)
         );
 
         assertEq(
@@ -285,7 +287,7 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
                     collateralTokenPrices: collateralTokenPrices,
                     collateralTokens: collateralTokens,
                     collateralAssetSymbols: collateralAssetSymbols,
-                    comet: COMET_1,
+                    comet: cometUsdc_(1),
                     price: USDC_PRICE,
                     token: usdc_(1)
                 })

--- a/test/builder/QuarkBuilderCometBorrow.t.sol
+++ b/test/builder/QuarkBuilderCometBorrow.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.23;
 import "forge-std/Test.sol";
 import "forge-std/console.sol";
 
+import {Arrays} from "test/builder/lib/Arrays.sol";
 import {QuarkBuilderTest, Accounts, PaymentInfo, QuarkBuilder} from "test/builder/lib/QuarkBuilderTest.sol";
 
 import {Actions} from "src/builder/Actions.sol";
@@ -31,7 +32,7 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
             chainId: chainId,
             collateralAmounts: collateralAmounts,
             collateralAssetSymbols: collateralAssetSymbols,
-            comet: COMET_1
+            comet: cometUsdc_(1)
         });
     }
 
@@ -84,15 +85,17 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
             chainId: 1,
             account: address(0xa11ce),
             nextNonce: 12,
-            assetSymbols: stringArray("USDC", "USDT", "LINK", "WETH"),
-            assetBalances: uintArray(0, 0, 10e18, 0) // user has 10 LINK
+            assetSymbols: Arrays.stringArray("USDC", "USDT", "LINK", "WETH"),
+            assetBalances: Arrays.uintArray(0, 0, 10e18, 0), // user has 10 LINK
+            cometPortfolios: emptyCometPortfolios_()
         });
         chainPortfolios[1] = ChainPortfolio({
             chainId: 8453,
             account: address(0xb0b),
             nextNonce: 2,
-            assetSymbols: stringArray("USDC", "USDT", "LINK", "WETH"),
-            assetBalances: uintArray(0, 0, 0, 0)
+            assetSymbols: Arrays.stringArray("USDC", "USDT", "LINK", "WETH"),
+            assetBalances: Arrays.uintArray(0, 0, 0, 0),
+            cometPortfolios: emptyCometPortfolios_()
         });
 
         QuarkBuilder builder = new QuarkBuilder();
@@ -137,9 +140,10 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeCall(
-                CometSupplyMultipleAssetsAndBorrow.run, (COMET_1, collateralTokens, collateralAmounts, usdc_(1), 1e6)
+                CometSupplyMultipleAssetsAndBorrow.run,
+                (cometUsdc_(1), collateralTokens, collateralAmounts, usdc_(1), 1e6)
             ),
-            "calldata is CometSupplyMultipleAssetsAndBorrow.run(COMET_1, [LINK], [1e18], USDC, 1e6);"
+            "calldata is CometSupplyMultipleAssetsAndBorrow.run(COMET_1_USDC, [LINK], [1e18], USDC, 1e6);"
         );
         assertEq(result.quarkOperations[0].scriptSources.length, 1);
         assertEq(result.quarkOperations[0].scriptSources[0], type(CometSupplyMultipleAssetsAndBorrow).creationCode);
@@ -170,7 +174,7 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
                     collateralTokenPrices: collateralTokenPrices,
                     collateralTokens: collateralTokens,
                     collateralAssetSymbols: collateralAssetSymbols,
-                    comet: COMET_1,
+                    comet: cometUsdc_(1),
                     price: USDC_PRICE,
                     token: usdc_(1)
                 })
@@ -307,15 +311,17 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
             chainId: 1,
             account: address(0xa11ce),
             nextNonce: 12,
-            assetSymbols: stringArray("USDC", "USDT", "LINK", "WETH"),
-            assetBalances: uintArray(1e6, 0, 10e18, 0) // user has 1 USDC, 10 LINK
+            assetSymbols: Arrays.stringArray("USDC", "USDT", "LINK", "WETH"),
+            assetBalances: Arrays.uintArray(1e6, 0, 10e18, 0), // user has 1 USDC, 10 LINK
+            cometPortfolios: emptyCometPortfolios_()
         });
         chainPortfolios[1] = ChainPortfolio({
             chainId: 8453,
             account: address(0xb0b),
             nextNonce: 2,
-            assetSymbols: stringArray("USDC", "USDT", "LINK", "WETH"),
-            assetBalances: uintArray(0, 0, 0, 0)
+            assetSymbols: Arrays.stringArray("USDC", "USDT", "LINK", "WETH"),
+            assetBalances: Arrays.uintArray(0, 0, 0, 0),
+            cometPortfolios: emptyCometPortfolios_()
         });
 
         PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](1);
@@ -358,7 +364,7 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
                 cometSupplyMultipleAssetsAndBorrowAddress,
                 abi.encodeWithSelector(
                     CometSupplyMultipleAssetsAndBorrow.run.selector,
-                    COMET_1,
+                    cometUsdc_(1),
                     collateralTokens,
                     collateralAmounts,
                     usdc_(1),
@@ -366,7 +372,7 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
                 ),
                 0.1e6
             ),
-            "calldata is Paycall.run(CometSupplyMultipleAssetsAndBorrow.run(COMET_1, [LINK_1], [1e18], USDC_1, 1e6), 0.1e6);"
+            "calldata is Paycall.run(CometSupplyMultipleAssetsAndBorrow.run(COMET_1_USDC, [LINK_1], [1e18], USDC_1, 1e6), 0.1e6);"
         );
         assertEq(result.quarkOperations[0].scriptSources.length, 2);
         assertEq(result.quarkOperations[0].scriptSources[0], type(CometSupplyMultipleAssetsAndBorrow).creationCode);
@@ -401,7 +407,7 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
                     collateralTokenPrices: collateralTokenPrices,
                     collateralTokens: collateralTokens,
                     collateralAssetSymbols: collateralAssetSymbols,
-                    comet: COMET_1,
+                    comet: cometUsdc_(1),
                     price: USDC_PRICE,
                     token: usdc_(1)
                 })
@@ -431,15 +437,17 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
             chainId: 1,
             account: address(0xa11ce),
             nextNonce: 12,
-            assetSymbols: stringArray("USDC", "USDT", "LINK", "WETH"),
-            assetBalances: uintArray(0, 0, 10e18, 0) // user has 10 LINK and 0 USDC
+            assetSymbols: Arrays.stringArray("USDC", "USDT", "LINK", "WETH"),
+            assetBalances: Arrays.uintArray(0, 0, 10e18, 0), // user has 10 LINK and 0 USDC
+            cometPortfolios: emptyCometPortfolios_()
         });
         chainPortfolios[1] = ChainPortfolio({
             chainId: 8453,
             account: address(0xb0b),
             nextNonce: 2,
-            assetSymbols: stringArray("USDC", "USDT", "LINK", "WETH"),
-            assetBalances: uintArray(0, 0, 0, 0)
+            assetSymbols: Arrays.stringArray("USDC", "USDT", "LINK", "WETH"),
+            assetBalances: Arrays.uintArray(0, 0, 0, 0),
+            cometPortfolios: emptyCometPortfolios_()
         });
 
         QuarkBuilder.BuilderResult memory result = builder.cometBorrow(
@@ -477,7 +485,7 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
                 cometSupplyMultipleAssetsAndBorrowAddress,
                 abi.encodeWithSelector(
                     CometSupplyMultipleAssetsAndBorrow.run.selector,
-                    COMET_1,
+                    cometUsdc_(1),
                     collateralTokens,
                     collateralAmounts,
                     usdc_(1),
@@ -485,7 +493,7 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
                 ),
                 0.5e6
             ),
-            "calldata is Paycall.run(CometSupplyMultipleAssetsAndBorrow.run.selector, (COMET_1, [LINK_1], [1e18], USDC_1, 1e6), .5e6);"
+            "calldata is Paycall.run(CometSupplyMultipleAssetsAndBorrow.run.selector, (COMET_1_USDC, [LINK_1], [1e18], USDC_1, 1e6), .5e6);"
         );
         assertEq(result.quarkOperations[0].scriptSources.length, 2);
         assertEq(result.quarkOperations[0].scriptSources[0], type(CometSupplyMultipleAssetsAndBorrow).creationCode);
@@ -520,7 +528,7 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
                     collateralTokenPrices: collateralTokenPrices,
                     collateralTokens: collateralTokens,
                     collateralAssetSymbols: collateralAssetSymbols,
-                    comet: COMET_1,
+                    comet: cometUsdc_(1),
                     price: USDC_PRICE,
                     token: usdc_(1)
                 })
@@ -552,15 +560,17 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
             chainId: 1,
             account: address(0xa11ce),
             nextNonce: 12,
-            assetSymbols: stringArray("USDC", "USDT", "LINK", "WETH"),
-            assetBalances: uintArray(3e6, 0, 0, 0) // 3 USDC on mainnet
+            assetSymbols: Arrays.stringArray("USDC", "USDT", "LINK", "WETH"),
+            assetBalances: Arrays.uintArray(3e6, 0, 0, 0), // 3 USDC on mainnet
+            cometPortfolios: emptyCometPortfolios_()
         });
         chainPortfolios[1] = ChainPortfolio({
             chainId: 8453,
             account: address(0xb0b),
             nextNonce: 2,
-            assetSymbols: stringArray("USDC", "USDT", "LINK", "WETH"),
-            assetBalances: uintArray(0, 0, 5e18, 0)
+            assetSymbols: Arrays.stringArray("USDC", "USDT", "LINK", "WETH"),
+            assetBalances: Arrays.uintArray(0, 0, 5e18, 0),
+            cometPortfolios: emptyCometPortfolios_()
         });
 
         QuarkBuilder.BuilderResult memory result = builder.cometBorrow(
@@ -635,7 +645,7 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
                 cometSupplyMultipleAssetsAndBorrowAddress,
                 abi.encodeWithSelector(
                     CometSupplyMultipleAssetsAndBorrow.run.selector,
-                    COMET_1,
+                    cometUsdc_(1),
                     collateralTokens,
                     collateralAmounts,
                     usdt_(8453),
@@ -643,7 +653,7 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
                 ),
                 1e6
             ),
-            "calldata is Paycall.run(CometSupplyMultipleAssetsAndBorrow.run(COMET_1, [LINK_8453], [1e18], USDT_8453, 1e6), 1e6);"
+            "calldata is Paycall.run(CometSupplyMultipleAssetsAndBorrow.run(COMET_1_USDC, [LINK_8453], [1e18], USDT_8453, 1e6), 1e6);"
         );
         assertEq(result.quarkOperations[1].scriptSources.length, 2);
         assertEq(result.quarkOperations[1].scriptSources[0], type(CometSupplyMultipleAssetsAndBorrow).creationCode);
@@ -702,7 +712,7 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
                     collateralTokenPrices: collateralTokenPrices,
                     collateralTokens: collateralTokens,
                     collateralAssetSymbols: collateralAssetSymbols,
-                    comet: COMET_1,
+                    comet: cometUsdc_(1),
                     price: USDT_PRICE,
                     token: usdt_(8453)
                 })
@@ -734,15 +744,17 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
             chainId: 1,
             account: address(0xa11ce),
             nextNonce: 12,
-            assetSymbols: stringArray("USDC", "USDT", "LINK", "WETH"),
-            assetBalances: uintArray(4e6, 0, 0, 0) // 4 USDC on mainnet
+            assetSymbols: Arrays.stringArray("USDC", "USDT", "LINK", "WETH"),
+            assetBalances: Arrays.uintArray(4e6, 0, 0, 0), // 4 USDC on mainnet
+            cometPortfolios: emptyCometPortfolios_()
         });
         chainPortfolios[1] = ChainPortfolio({
             chainId: 8453,
             account: address(0xb0b),
             nextNonce: 2,
-            assetSymbols: stringArray("USDC", "USDT", "LINK", "WETH"),
-            assetBalances: uintArray(0, 0, 0, 0) // no assets on base
+            assetSymbols: Arrays.stringArray("USDC", "USDT", "LINK", "WETH"),
+            assetBalances: Arrays.uintArray(0, 0, 0, 0), // no assets on base
+            cometPortfolios: emptyCometPortfolios_()
         });
 
         QuarkBuilder.BuilderResult memory result = builder.cometBorrow(
@@ -817,7 +829,7 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
                 cometSupplyMultipleAssetsAndBorrowAddress,
                 abi.encodeWithSelector(
                     CometSupplyMultipleAssetsAndBorrow.run.selector,
-                    COMET_1,
+                    cometUsdc_(1),
                     collateralTokens,
                     collateralAmounts,
                     weth_(8453),
@@ -825,7 +837,7 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
                 ),
                 0.2e6
             ),
-            "calldata is Paycall.run(CometSupplyMultipleAssetsAndBorrow.run(COMET_1, [USDC_8453], [2e6], WETH_8453, 1e18), 0.2e6);"
+            "calldata is Paycall.run(CometSupplyMultipleAssetsAndBorrow.run(COMET_1_USDC, [USDC_8453], [2e6], WETH_8453, 1e18), 0.2e6);"
         );
         assertEq(result.quarkOperations[1].scriptSources.length, 2);
         assertEq(result.quarkOperations[1].scriptSources[0], type(CometSupplyMultipleAssetsAndBorrow).creationCode);
@@ -884,7 +896,7 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
                     collateralTokenPrices: collateralTokenPrices,
                     collateralTokens: collateralTokens,
                     collateralAssetSymbols: collateralAssetSymbols,
-                    comet: COMET_1,
+                    comet: cometUsdc_(1),
                     price: WETH_PRICE,
                     token: weth_(8453)
                 })

--- a/test/builder/QuarkBuilderCometRepay.t.sol
+++ b/test/builder/QuarkBuilderCometRepay.t.sol
@@ -276,7 +276,8 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
         callDatas[0] =
             abi.encodeWithSelector(WrapperActions.wrapETH.selector, 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, 1e18);
         callDatas[1] = abi.encodeCall(
-            CometRepayAndWithdrawMultipleAssets.run, (cometUsdc_(1), collateralTokens, collateralAmounts, weth_(1), 1e18)
+            CometRepayAndWithdrawMultipleAssets.run,
+            (cometUsdc_(1), collateralTokens, collateralAmounts, weth_(1), 1e18)
         );
 
         assertEq(

--- a/test/builder/QuarkBuilderCometRepay.t.sol
+++ b/test/builder/QuarkBuilderCometRepay.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.23;
 import "forge-std/Test.sol";
 import "forge-std/console.sol";
 
+import {Arrays} from "test/builder/lib/Arrays.sol";
 import {QuarkBuilderTest, Accounts, PaymentInfo, QuarkBuilder} from "test/builder/lib/QuarkBuilderTest.sol";
 
 import {Actions} from "src/builder/Actions.sol";
@@ -30,7 +31,7 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
             chainId: chainId,
             collateralAmounts: collateralAmounts,
             collateralAssetSymbols: collateralAssetSymbols,
-            comet: COMET_1,
+            comet: cometUsdc_(1),
             repayer: address(0xa11ce)
         });
     }
@@ -82,8 +83,9 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
             chainId: 1,
             account: address(0xa11ce),
             nextNonce: 12,
-            assetSymbols: stringArray("USDC", "USDT", "LINK", "WETH"),
-            assetBalances: uintArray(0.4e6, 0, 0, 1e18) // user does not have enough USDC
+            assetSymbols: Arrays.stringArray("USDC", "USDT", "LINK", "WETH"),
+            assetBalances: Arrays.uintArray(0.4e6, 0, 0, 1e18), // user does not have enough USDC
+            cometPortfolios: emptyCometPortfolios_()
         });
 
         vm.expectRevert(QuarkBuilder.MaxCostTooHigh.selector);
@@ -107,15 +109,17 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
             chainId: 1,
             account: address(0xa11ce),
             nextNonce: 12,
-            assetSymbols: stringArray("USDC", "USDT", "LINK", "WETH"),
-            assetBalances: uintArray(1e6, 0, 0, 0) // has 1 USDC
+            assetSymbols: Arrays.stringArray("USDC", "USDT", "LINK", "WETH"),
+            assetBalances: Arrays.uintArray(1e6, 0, 0, 0), // has 1 USDC
+            cometPortfolios: emptyCometPortfolios_()
         });
         chainPortfolios[1] = ChainPortfolio({
             chainId: 8453,
             account: address(0xb0b),
             nextNonce: 2,
-            assetSymbols: stringArray("USDC", "USDT", "LINK", "WETH"),
-            assetBalances: uintArray(0, 0, 0, 0)
+            assetSymbols: Arrays.stringArray("USDC", "USDT", "LINK", "WETH"),
+            assetBalances: Arrays.uintArray(0, 0, 0, 0),
+            cometPortfolios: emptyCometPortfolios_()
         });
 
         QuarkBuilder builder = new QuarkBuilder();
@@ -160,9 +164,10 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeCall(
-                CometRepayAndWithdrawMultipleAssets.run, (COMET_1, collateralTokens, collateralAmounts, usdc_(1), 1e6)
+                CometRepayAndWithdrawMultipleAssets.run,
+                (cometUsdc_(1), collateralTokens, collateralAmounts, usdc_(1), 1e6)
             ),
-            "calldata is CometRepayAndWithdrawMultipleAssets.run(COMET_1, [LINK], [1e18], USDC, 1e6);"
+            "calldata is CometRepayAndWithdrawMultipleAssets.run(COMET_1_USDC, [LINK], [1e18], USDC, 1e6);"
         );
         assertEq(result.quarkOperations[0].scriptSources.length, 1);
         assertEq(result.quarkOperations[0].scriptSources[0], type(CometRepayAndWithdrawMultipleAssets).creationCode);
@@ -193,7 +198,7 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
                     collateralAssetSymbols: collateralAssetSymbols,
                     collateralTokenPrices: collateralTokenPrices,
                     collateralTokens: collateralTokens,
-                    comet: COMET_1,
+                    comet: cometUsdc_(1),
                     price: USDC_PRICE,
                     token: usdc_(1)
                 })
@@ -330,15 +335,17 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
             chainId: 1,
             account: address(0xa11ce),
             nextNonce: 12,
-            assetSymbols: stringArray("USDC", "USDT", "LINK", "WETH"),
-            assetBalances: uintArray(2e6, 0, 0, 0)
+            assetSymbols: Arrays.stringArray("USDC", "USDT", "LINK", "WETH"),
+            assetBalances: Arrays.uintArray(2e6, 0, 0, 0),
+            cometPortfolios: emptyCometPortfolios_()
         });
         chainPortfolios[1] = ChainPortfolio({
             chainId: 8453,
             account: address(0xb0b),
             nextNonce: 2,
-            assetSymbols: stringArray("USDC", "USDT", "LINK", "WETH"),
-            assetBalances: uintArray(0, 0, 0, 0)
+            assetSymbols: Arrays.stringArray("USDC", "USDT", "LINK", "WETH"),
+            assetBalances: Arrays.uintArray(0, 0, 0, 0),
+            cometPortfolios: emptyCometPortfolios_()
         });
 
         PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](1);
@@ -381,7 +388,7 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
                 cometRepayAndWithdrawMultipleAssetsAddress,
                 abi.encodeWithSelector(
                     CometRepayAndWithdrawMultipleAssets.run.selector,
-                    COMET_1,
+                    cometUsdc_(1),
                     collateralTokens,
                     collateralAmounts,
                     usdc_(1),
@@ -389,7 +396,7 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
                 ),
                 0.1e6
             ),
-            "calldata is Paycall.run(CometRepayAndWithdrawMultipleAssets.run(COMET_1, [LINK_1], [1e18], USDC_1, 1e6), 0.1e6);"
+            "calldata is Paycall.run(CometRepayAndWithdrawMultipleAssets.run(cometUsdc_(1), [LINK_1], [1e18], USDC_1, 1e6), 0.1e6);"
         );
         assertEq(result.quarkOperations[0].scriptSources.length, 2);
         assertEq(result.quarkOperations[0].scriptSources[0], type(CometRepayAndWithdrawMultipleAssets).creationCode);
@@ -424,7 +431,7 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
                     collateralAssetSymbols: collateralAssetSymbols,
                     collateralTokenPrices: collateralTokenPrices,
                     collateralTokens: collateralTokens,
-                    comet: COMET_1,
+                    comet: cometUsdc_(1),
                     price: USDC_PRICE,
                     token: usdc_(1)
                 })
@@ -455,15 +462,17 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
             chainId: 1,
             account: address(0xa11ce),
             nextNonce: 12,
-            assetSymbols: stringArray("USDC", "USDT", "LINK", "WETH"),
-            assetBalances: uintArray(0, 0, 0, 1e18)
+            assetSymbols: Arrays.stringArray("USDC", "USDT", "LINK", "WETH"),
+            assetBalances: Arrays.uintArray(0, 0, 0, 1e18),
+            cometPortfolios: emptyCometPortfolios_()
         });
         chainPortfolios[1] = ChainPortfolio({
             chainId: 8453,
             account: address(0xb0b),
             nextNonce: 2,
-            assetSymbols: stringArray("USDC", "USDT", "LINK", "WETH"),
-            assetBalances: uintArray(0, 0, 0, 0)
+            assetSymbols: Arrays.stringArray("USDC", "USDT", "LINK", "WETH"),
+            assetBalances: Arrays.uintArray(0, 0, 0, 0),
+            cometPortfolios: emptyCometPortfolios_()
         });
 
         QuarkBuilder.BuilderResult memory result = builder.cometRepay(
@@ -501,7 +510,7 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
                 cometRepayAndWithdrawMultipleAssetsAddress,
                 abi.encodeWithSelector(
                     CometRepayAndWithdrawMultipleAssets.run.selector,
-                    COMET_1,
+                    cometUsdc_(1),
                     collateralTokens,
                     collateralAmounts,
                     weth_(1),
@@ -509,7 +518,7 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
                 ),
                 0.5e6
             ),
-            "calldata is Paycall.run(CometRepayAndWithdrawMultipleAssets.run(COMET_1, [USDC_1], [1e6], WETH_1, 1e18), 0.5e6);"
+            "calldata is Paycall.run(CometRepayAndWithdrawMultipleAssets.run(cometUsdc_(1), [USDC_1], [1e6], WETH_1, 1e18), 0.5e6);"
         );
 
         assertEq(result.quarkOperations[0].scriptSources.length, 2);
@@ -545,7 +554,7 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
                     collateralAssetSymbols: collateralAssetSymbols,
                     collateralTokenPrices: collateralTokenPrices,
                     collateralTokens: collateralTokens,
-                    comet: COMET_1,
+                    comet: cometUsdc_(1),
                     price: WETH_PRICE,
                     token: weth_(1)
                 })
@@ -577,15 +586,17 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
             chainId: 1,
             account: address(0xa11ce),
             nextNonce: 12,
-            assetSymbols: stringArray("USDC", "USDT", "LINK", "WETH"),
-            assetBalances: uintArray(4e6, 0, 0, 0) // 4 USDC on mainnet
+            assetSymbols: Arrays.stringArray("USDC", "USDT", "LINK", "WETH"),
+            assetBalances: Arrays.uintArray(4e6, 0, 0, 0), // 4 USDC on mainnet
+            cometPortfolios: emptyCometPortfolios_()
         });
         chainPortfolios[1] = ChainPortfolio({
             chainId: 8453,
             account: address(0xb0b),
             nextNonce: 2,
-            assetSymbols: stringArray("USDC", "USDT", "LINK", "WETH"),
-            assetBalances: uintArray(0, 0, 0, 0) // no assets on base
+            assetSymbols: Arrays.stringArray("USDC", "USDT", "LINK", "WETH"),
+            assetBalances: Arrays.uintArray(0, 0, 0, 0), // no assets on base
+            cometPortfolios: emptyCometPortfolios_()
         });
 
         QuarkBuilder.BuilderResult memory result = builder.cometRepay(
@@ -660,7 +671,7 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
                 cometRepayAndWithdrawMultipleAssetsAddress,
                 abi.encodeWithSelector(
                     CometRepayAndWithdrawMultipleAssets.run.selector,
-                    COMET_1,
+                    cometUsdc_(1),
                     collateralTokens,
                     collateralAmounts,
                     usdc_(8453),
@@ -668,7 +679,7 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
                 ),
                 0.2e6
             ),
-            "calldata is Paycall.run(CometRepayAndWithdrawMultipleAssets.run(COMET_1, [LINK_8453], [1e18], USDC_8453, 2e6), 0.2e6);"
+            "calldata is Paycall.run(CometRepayAndWithdrawMultipleAssets.run(cometUsdc_(1), [LINK_8453], [1e18], USDC_8453, 2e6), 0.2e6);"
         );
         assertEq(result.quarkOperations[1].scriptSources.length, 2);
         assertEq(result.quarkOperations[1].scriptSources[0], type(CometRepayAndWithdrawMultipleAssets).creationCode);
@@ -727,7 +738,7 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
                     collateralAssetSymbols: collateralAssetSymbols,
                     collateralTokenPrices: collateralTokenPrices,
                     collateralTokens: collateralTokens,
-                    comet: COMET_1,
+                    comet: cometUsdc_(1),
                     price: USDC_PRICE,
                     token: usdc_(8453)
                 })

--- a/test/builder/QuarkBuilderCometRepay.t.sol
+++ b/test/builder/QuarkBuilderCometRepay.t.sol
@@ -230,15 +230,17 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
             chainId: 1,
             account: address(0xa11ce),
             nextNonce: 12,
-            assetSymbols: stringArray("USDC", "ETH", "LINK", "WETH"),
-            assetBalances: uintArray(0, 1e18, 0, 0) // has 1 ETH
+            assetSymbols: Arrays.stringArray("USDC", "ETH", "LINK", "WETH"),
+            assetBalances: Arrays.uintArray(0, 1e18, 0, 0), // has 1 ETH
+            cometPortfolios: emptyCometPortfolios_()
         });
         chainPortfolios[1] = ChainPortfolio({
             chainId: 8453,
             account: address(0xb0b),
             nextNonce: 2,
-            assetSymbols: stringArray("USDC", "ETH", "LINK", "WETH"),
-            assetBalances: uintArray(0, 0, 0, 0)
+            assetSymbols: Arrays.stringArray("USDC", "ETH", "LINK", "WETH"),
+            assetBalances: Arrays.uintArray(0, 0, 0, 0),
+            cometPortfolios: emptyCometPortfolios_()
         });
 
         QuarkBuilder builder = new QuarkBuilder();
@@ -274,7 +276,7 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
         callDatas[0] =
             abi.encodeWithSelector(WrapperActions.wrapETH.selector, 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, 1e18);
         callDatas[1] = abi.encodeCall(
-            CometRepayAndWithdrawMultipleAssets.run, (COMET_1, collateralTokens, collateralAmounts, weth_(1), 1e18)
+            CometRepayAndWithdrawMultipleAssets.run, (cometUsdc_(1), collateralTokens, collateralAmounts, weth_(1), 1e18)
         );
 
         assertEq(
@@ -309,7 +311,7 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
                     collateralAssetSymbols: collateralAssetSymbols,
                     collateralTokenPrices: collateralTokenPrices,
                     collateralTokens: collateralTokens,
-                    comet: COMET_1,
+                    comet: cometUsdc_(1),
                     price: WETH_PRICE,
                     token: weth_(1)
                 })

--- a/test/builder/QuarkBuilderCometSupply.t.sol
+++ b/test/builder/QuarkBuilderCometSupply.t.sol
@@ -180,7 +180,8 @@ contract QuarkBuilderCometSupplyTest is Test, QuarkBuilderTest {
         chainAccountsList[0] = Accounts.ChainAccounts({
             chainId: 1,
             quarkStates: quarkStates_(address(0xa11ce), 12),
-            assetPositionsList: assetPositionsList
+            assetPositionsList: assetPositionsList,
+            cometPositions: emptyCometPositions_()
         });
 
         QuarkBuilder.BuilderResult memory result =

--- a/test/builder/QuarkBuilderCometWithdraw.t.sol
+++ b/test/builder/QuarkBuilderCometWithdraw.t.sol
@@ -446,7 +446,7 @@ contract QuarkBuilderCometWithdrawTest is Test, QuarkBuilderTest {
             result.actions[0].actionContext,
             abi.encode(
                 Actions.WithdrawActionContext({
-                    amount: type(uint256).max, // ?? should this be a different amount?
+                    amount: type(uint256).max,
                     assetSymbol: "USDC",
                     chainId: 1,
                     comet: cometUsdc_(1),

--- a/test/builder/QuarkBuilderCometWithdraw.t.sol
+++ b/test/builder/QuarkBuilderCometWithdraw.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.23;
 
 import "forge-std/Test.sol";
 
+import {Arrays} from "test/builder/lib/Arrays.sol";
 import {Accounts, PaymentInfo, QuarkBuilder, QuarkBuilderTest} from "test/builder/lib/QuarkBuilderTest.sol";
 
 import {Actions} from "src/builder/Actions.sol";
@@ -10,11 +11,10 @@ import {CCTPBridgeActions} from "src/BridgeScripts.sol";
 import {CodeJarHelper} from "src/builder/CodeJarHelper.sol";
 import {CometWithdrawActions, TransferActions} from "src/DeFiScripts.sol";
 import {Paycall} from "src/Paycall.sol";
+import {Quotecall} from "src/Quotecall.sol";
 
 contract QuarkBuilderCometWithdrawTest is Test, QuarkBuilderTest {
-    address constant COMET = address(0xc3);
-
-    function cometWithdraw_(uint256 chainId, uint256 amount, string memory assetSymbol)
+    function cometWithdraw_(uint256 chainId, address comet, string memory assetSymbol, uint256 amount)
         internal
         pure
         returns (QuarkBuilder.CometWithdrawIntent memory)
@@ -24,7 +24,7 @@ contract QuarkBuilderCometWithdrawTest is Test, QuarkBuilderTest {
             assetSymbol: assetSymbol,
             blockTimestamp: BLOCK_TIMESTAMP,
             chainId: chainId,
-            comet: COMET,
+            comet: comet,
             withdrawer: address(0xa11ce)
         });
     }
@@ -34,7 +34,7 @@ contract QuarkBuilderCometWithdrawTest is Test, QuarkBuilderTest {
     function testCometWithdraw() public {
         QuarkBuilder builder = new QuarkBuilder();
         QuarkBuilder.BuilderResult memory result = builder.cometWithdraw(
-            cometWithdraw_(1, 1e18, "LINK"),
+            cometWithdraw_(1, cometUsdc_(1), "LINK", 1e18),
             chainAccountsList_(2e6), // holding 2 USDC in total across 1, 8453
             paymentUsd_()
         );
@@ -65,8 +65,8 @@ contract QuarkBuilderCometWithdrawTest is Test, QuarkBuilderTest {
         );
         assertEq(
             result.quarkOperations[0].scriptCalldata,
-            abi.encodeCall(CometWithdrawActions.withdraw, (COMET, link_(1), 1e18)),
-            "calldata is CometWithdrawActions.withdraw(COMET, LINK_1, 1e18);"
+            abi.encodeCall(CometWithdrawActions.withdraw, (cometUsdc_(1), link_(1), 1e18)),
+            "calldata is CometWithdrawActions.withdraw(cometUsdc_(1), LINK_1, 1e18);"
         );
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
@@ -87,7 +87,7 @@ contract QuarkBuilderCometWithdrawTest is Test, QuarkBuilderTest {
                     amount: 1e18,
                     assetSymbol: "LINK",
                     chainId: 1,
-                    comet: COMET,
+                    comet: cometUsdc_(1),
                     price: LINK_PRICE,
                     token: link_(1)
                 })
@@ -106,7 +106,7 @@ contract QuarkBuilderCometWithdrawTest is Test, QuarkBuilderTest {
         PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](1);
         maxCosts[0] = PaymentInfo.PaymentMaxCost({chainId: 1, amount: 0.1e6});
         QuarkBuilder.BuilderResult memory result = builder.cometWithdraw(
-            cometWithdraw_(1, 1e18, "LINK"),
+            cometWithdraw_(1, cometUsdc_(1), "LINK", 1e18),
             chainAccountsList_(3e6), // holding 3 USDC in total across chains 1, 8453
             paymentUsdc_(maxCosts)
         );
@@ -128,10 +128,10 @@ contract QuarkBuilderCometWithdrawTest is Test, QuarkBuilderTest {
             abi.encodeWithSelector(
                 Paycall.run.selector,
                 cometWithdrawActionsAddress,
-                abi.encodeWithSelector(CometWithdrawActions.withdraw.selector, COMET, link_(1), 1e18),
+                abi.encodeWithSelector(CometWithdrawActions.withdraw.selector, cometUsdc_(1), link_(1), 1e18),
                 0.1e6
             ),
-            "calldata is Paycall.run(CometWithdrawActions.withdraw(COMET, LINK_1, 1e18), 0.1e6);"
+            "calldata is Paycall.run(CometWithdrawActions.withdraw(cometUsdc_(1), LINK_1, 1e18), 0.1e6);"
         );
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
@@ -152,7 +152,7 @@ contract QuarkBuilderCometWithdrawTest is Test, QuarkBuilderTest {
                     amount: 1e18,
                     assetSymbol: "LINK",
                     chainId: 1,
-                    comet: COMET,
+                    comet: cometUsdc_(1),
                     price: LINK_PRICE,
                     token: link_(1)
                 })
@@ -171,7 +171,7 @@ contract QuarkBuilderCometWithdrawTest is Test, QuarkBuilderTest {
         PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](1);
         maxCosts[0] = PaymentInfo.PaymentMaxCost({chainId: 1, amount: 0.5e6}); // action costs .5 USDC
         QuarkBuilder.BuilderResult memory result = builder.cometWithdraw(
-            cometWithdraw_(1, 1e6, "USDC"), // user will be withdrawing 1 USDC
+            cometWithdraw_(1, cometUsdc_(1), "USDC", 1e6), // user will be withdrawing 1 USDC
             chainAccountsList_(0), // and has no additional USDC balance
             paymentUsdc_(maxCosts)
         );
@@ -193,7 +193,7 @@ contract QuarkBuilderCometWithdrawTest is Test, QuarkBuilderTest {
             abi.encodeWithSelector(
                 Paycall.run.selector,
                 cometWithdrawActionsAddress,
-                abi.encodeWithSelector(CometWithdrawActions.withdraw.selector, COMET, usdc_(1), 1e6),
+                abi.encodeWithSelector(CometWithdrawActions.withdraw.selector, cometUsdc_(1), usdc_(1), 1e6),
                 0.5e6
             ),
             "calldata is Paycall.run(CometWithdrawActions.withdraw(COMET, USDC_1, 1e6), 0.5e6);"
@@ -217,7 +217,7 @@ contract QuarkBuilderCometWithdrawTest is Test, QuarkBuilderTest {
                     amount: 1e6,
                     assetSymbol: "USDC",
                     chainId: 1,
-                    comet: COMET,
+                    comet: cometUsdc_(1),
                     price: USDC_PRICE,
                     token: usdc_(1)
                 })
@@ -238,7 +238,7 @@ contract QuarkBuilderCometWithdrawTest is Test, QuarkBuilderTest {
         maxCosts[1] = PaymentInfo.PaymentMaxCost({chainId: 8453, amount: 0.1e6});
         vm.expectRevert(abi.encodeWithSelector(Actions.NotEnoughFundsToBridge.selector, "usdc", 9.98e8, 9.971e8));
         builder.cometWithdraw(
-            cometWithdraw_(1, 1e6, "USDC"),
+            cometWithdraw_(1, cometUsdc_(1), "USDC", 1e6),
             chainAccountsList_(2e6), // holding 2 USDC in total across 1, 8453
             paymentUsdc_(maxCosts)
         );
@@ -255,16 +255,19 @@ contract QuarkBuilderCometWithdrawTest is Test, QuarkBuilderTest {
         chainAccountsList[0] = Accounts.ChainAccounts({
             chainId: 1,
             quarkStates: quarkStates_(address(0xa11ce), 12),
-            assetPositionsList: assetPositionsList_(1, address(0xa11ce), 3e6) // 3 USDC on mainnet
+            assetPositionsList: assetPositionsList_(1, address(0xa11ce), 3e6), // 3 USDC on mainnet
+            cometPositions: emptyCometPositions_()
         });
         chainAccountsList[1] = Accounts.ChainAccounts({
             chainId: 8453,
             quarkStates: quarkStates_(address(0xb0b), 2),
-            assetPositionsList: assetPositionsList_(8453, address(0xb0b), 0) // 0 USDC on base
+            assetPositionsList: assetPositionsList_(8453, address(0xb0b), 0), // 0 USDC on base
+            cometPositions: emptyCometPositions_()
         });
 
-        QuarkBuilder.BuilderResult memory result =
-            builder.cometWithdraw(cometWithdraw_(8453, 5e18, "LINK"), chainAccountsList, paymentUsdc_(maxCosts));
+        QuarkBuilder.BuilderResult memory result = builder.cometWithdraw(
+            cometWithdraw_(8453, cometUsdc_(8453), "LINK", 5e18), chainAccountsList, paymentUsdc_(maxCosts)
+        );
 
         address paycallAddress = paycallUsdc_(1);
         address paycallAddressBase = paycallUsdc_(8453);
@@ -312,7 +315,7 @@ contract QuarkBuilderCometWithdrawTest is Test, QuarkBuilderTest {
             abi.encodeWithSelector(
                 Paycall.run.selector,
                 CodeJarHelper.getCodeAddress(type(CometWithdrawActions).creationCode),
-                abi.encodeCall(CometWithdrawActions.withdraw, (COMET, link_(8453), 5e18)),
+                abi.encodeCall(CometWithdrawActions.withdraw, (cometUsdc_(8453), link_(8453), 5e18)),
                 1e6
             ),
             "calldata is Paycall.run(CometWithdrawActions.withdraw(COMET, LINK_8453, 5e18), 1e6);"
@@ -360,7 +363,7 @@ contract QuarkBuilderCometWithdrawTest is Test, QuarkBuilderTest {
                     amount: 5e18,
                     assetSymbol: "LINK",
                     chainId: 8453,
-                    comet: COMET,
+                    comet: cometUsdc_(8453),
                     price: LINK_PRICE,
                     token: link_(8453)
                 })
@@ -373,4 +376,129 @@ contract QuarkBuilderCometWithdrawTest is Test, QuarkBuilderTest {
         assertNotEq(result.eip712Data.domainSeparator, hex"", "non-empty domain separator");
         assertNotEq(result.eip712Data.hashStruct, hex"", "non-empty hashStruct");
     }
+
+    function testCometWithdrawMaxRevertsMaxCostTooHigh() public {
+        PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](1);
+        maxCosts[0] = PaymentInfo.PaymentMaxCost({chainId: 1, amount: 100e6}); // max cost is very high
+
+        CometPortfolio[] memory cometPortfolios = new CometPortfolio[](1);
+        cometPortfolios[0] = CometPortfolio({
+            comet: cometUsdc_(1),
+            baseSupplied: 1e6,
+            baseBorrowed: 0,
+            collateralAssetSymbols: Arrays.stringArray("LINK"),
+            collateralAssetBalances: Arrays.uintArray(0)
+        });
+
+        ChainPortfolio[] memory chainPortfolios = new ChainPortfolio[](1);
+        chainPortfolios[0] = ChainPortfolio({
+            chainId: 1,
+            account: address(0xa11ce),
+            nextNonce: 12,
+            assetSymbols: Arrays.stringArray("USDC", "USDT", "LINK", "WETH"),
+            assetBalances: Arrays.uintArray(0, 0, 0, 0),
+            cometPortfolios: cometPortfolios
+        });
+
+        QuarkBuilder builder = new QuarkBuilder();
+
+        vm.expectRevert(QuarkBuilder.MaxCostTooHigh.selector);
+
+        builder.cometWithdraw(
+            cometWithdraw_(1, cometUsdc_(1), "USDC", type(uint256).max),
+            chainAccountsFromChainPortfolios(chainPortfolios),
+            paymentUsdc_(maxCosts) // user will pay for transaction with withdrawn funds, but it is not enough
+        );
+    }
+
+    function testCometWithdrawMax() public {
+        PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](1);
+        maxCosts[0] = PaymentInfo.PaymentMaxCost({chainId: 1, amount: 0.1e6});
+
+        CometPortfolio[] memory cometPortfolios = new CometPortfolio[](1);
+        cometPortfolios[0] = CometPortfolio({
+            comet: cometUsdc_(1),
+            baseSupplied: 1e6,
+            baseBorrowed: 0,
+            collateralAssetSymbols: Arrays.stringArray("LINK"),
+            collateralAssetBalances: Arrays.uintArray(0)
+        });
+
+        ChainPortfolio[] memory chainPortfolios = new ChainPortfolio[](1);
+        chainPortfolios[0] = ChainPortfolio({
+            chainId: 1,
+            account: address(0xa11ce),
+            nextNonce: 12,
+            assetSymbols: Arrays.stringArray("USDC", "USDT", "LINK", "WETH"),
+            assetBalances: Arrays.uintArray(0, 0, 0, 0),
+            cometPortfolios: cometPortfolios
+        });
+
+        QuarkBuilder builder = new QuarkBuilder();
+        QuarkBuilder.BuilderResult memory result = builder.cometWithdraw(
+            cometWithdraw_(1, cometUsdc_(1), "USDC", type(uint256).max),
+            chainAccountsFromChainPortfolios(chainPortfolios), // user has no assets
+            paymentUsdc_(maxCosts) // but will pay from withdrawn funds
+        );
+
+        address quoteCallAddress = CodeJarHelper.getCodeAddress(
+            abi.encodePacked(type(Quotecall).creationCode, abi.encode(ETH_USD_PRICE_FEED_1, USDC_1))
+        );
+        address cometWithdrawActionsAddress = CodeJarHelper.getCodeAddress(type(CometWithdrawActions).creationCode);
+
+        assertEq(result.paymentCurrency, "usdc", "usdc currency");
+
+        // Check the quark operations
+        assertEq(result.quarkOperations.length, 1, "one operation");
+        assertEq(
+            result.quarkOperations[0].scriptAddress,
+            quoteCallAddress,
+            "script address is correct given the code jar address on mainnet"
+        );
+        assertEq(
+            result.quarkOperations[0].scriptCalldata,
+            abi.encodeWithSelector(
+                Quotecall.run.selector,
+                cometWithdrawActionsAddress,
+                abi.encodeWithSelector(
+                    CometWithdrawActions.withdraw.selector, cometUsdc_(1), usdc_(1), type(uint256).max
+                ),
+                0.1e6
+            ),
+            "calldata is Quotecall.run(CometWithdrawActions.withdraw(COMET, USDC_1, uint256.max), 0.1e6);"
+        );
+        assertEq(
+            result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
+        );
+
+        // check the actions
+        assertEq(result.actions.length, 1, "one action");
+        assertEq(result.actions[0].chainId, 1, "operation is on chainId 1");
+        assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
+        assertEq(result.actions[0].actionType, "WITHDRAW", "action type is 'WITHDRAW'");
+        assertEq(result.actions[0].paymentMethod, "QUOTE_CALL", "payment method is 'QUOTE_CALL'");
+        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC");
+        assertEq(result.actions[0].paymentMaxCost, 0.1e6, "payment max is set to 0.1e6");
+        assertEq(
+            result.actions[0].actionContext,
+            abi.encode(
+                Actions.WithdrawActionContext({
+                    amount: type(uint256).max, // ?? should this be a different amount?
+                    assetSymbol: "USDC",
+                    chainId: 1,
+                    comet: cometUsdc_(1),
+                    price: USDC_PRICE,
+                    token: usdc_(1)
+                })
+            ),
+            "action context encoded from WithdrawActionContext"
+        );
+
+        // TODO: Check the contents of the EIP712 data
+        assertNotEq(result.eip712Data.digest, hex"", "non-empty digest");
+        assertNotEq(result.eip712Data.domainSeparator, hex"", "non-empty domain separator");
+        assertNotEq(result.eip712Data.hashStruct, hex"", "non-empty hashStruct");
+    }
+
+    // XXX reverts if the withdrawn amount is not sufficient to cover the cost of the action
 }

--- a/test/builder/QuarkBuilderSwap.t.sol
+++ b/test/builder/QuarkBuilderSwap.t.sol
@@ -247,7 +247,8 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
         chainAccountsList[0] = Accounts.ChainAccounts({
             chainId: 1,
             quarkStates: quarkStates_(address(0xa11ce), 12),
-            assetPositionsList: assetPositionsList
+            assetPositionsList: assetPositionsList,
+            cometPositions: emptyCometPositions_()
         });
         QuarkBuilder.BuilderResult memory result = builder.swap(
             buyUsdc_(1, weth_(1), 1e18, 3000e6, address(0xa11ce), BLOCK_TIMESTAMP), // swap 1 ETH on chain 1 to 3000 USDC

--- a/test/builder/QuarkBuilderTransfer.t.sol
+++ b/test/builder/QuarkBuilderTransfer.t.sol
@@ -608,7 +608,8 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         chainAccountsList[0] = Accounts.ChainAccounts({
             chainId: 1,
             quarkStates: quarkStates_(address(0xa11ce), 12),
-            assetPositionsList: assetPositionsList_(1, address(0xa11ce), uint256(10e6))
+            assetPositionsList: assetPositionsList_(1, address(0xa11ce), uint256(10e6)),
+            cometPositions: emptyCometPositions_()
         });
 
         QuarkBuilder.BuilderResult memory result = builder.transfer(
@@ -683,12 +684,14 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         chainAccountsList[0] = Accounts.ChainAccounts({
             chainId: 1,
             quarkStates: quarkStates_(address(0xa11ce), 12),
-            assetPositionsList: assetPositionsList_(1, address(0xa11ce), 8e6)
+            assetPositionsList: assetPositionsList_(1, address(0xa11ce), 8e6),
+            cometPositions: emptyCometPositions_()
         });
         chainAccountsList[1] = Accounts.ChainAccounts({
             chainId: 8453,
             quarkStates: quarkStates_(address(0xb0b), 2),
-            assetPositionsList: assetPositionsList_(8453, address(0xb0b), 4e6)
+            assetPositionsList: assetPositionsList_(8453, address(0xb0b), 4e6),
+            cometPositions: emptyCometPositions_()
         });
 
         QuarkBuilder.BuilderResult memory result = builder.transfer(
@@ -816,17 +819,20 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         chainAccountsList[0] = Accounts.ChainAccounts({
             chainId: 1,
             quarkStates: quarkStates_(address(0xa11ce), 12),
-            assetPositionsList: assetPositionsList_(1, address(0xa11ce), 8e6)
+            assetPositionsList: assetPositionsList_(1, address(0xa11ce), 8e6),
+            cometPositions: emptyCometPositions_()
         });
         chainAccountsList[1] = Accounts.ChainAccounts({
             chainId: 8453,
             quarkStates: quarkStates_(address(0xb0b), 2),
-            assetPositionsList: assetPositionsList_(8453, address(0xb0b), 4e6)
+            assetPositionsList: assetPositionsList_(8453, address(0xb0b), 4e6),
+            cometPositions: emptyCometPositions_()
         });
         chainAccountsList[2] = Accounts.ChainAccounts({
             chainId: 7777,
             quarkStates: quarkStates_(address(0xfe11a), 2),
-            assetPositionsList: assetPositionsList_(7777, address(0xfe11a), 5e6)
+            assetPositionsList: assetPositionsList_(7777, address(0xfe11a), 5e6),
+            cometPositions: emptyCometPositions_()
         });
 
         // User has total holding of 17 USDC, but only 12 USDC is available for transfer/bridge to 8453, and missing 5 USDC stuck in random L2 so will revert with FundsUnavailable error
@@ -912,7 +918,8 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         chainAccountsList[0] = Accounts.ChainAccounts({
             chainId: 1,
             quarkStates: quarkStates_(address(0xa11ce), 12),
-            assetPositionsList: assetPositionsList
+            assetPositionsList: assetPositionsList,
+            cometPositions: emptyCometPositions_()
         });
 
         // Transfer 1.5ETH to 0xceecee on chain 1
@@ -1012,7 +1019,8 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         chainAccountsList[0] = Accounts.ChainAccounts({
             chainId: 1,
             quarkStates: quarkStates_(address(0xa11ce), 12),
-            assetPositionsList: assetPositionsList
+            assetPositionsList: assetPositionsList,
+            cometPositions: emptyCometPositions_()
         });
 
         // Transfer 1.5ETH to 0xceecee on chain 1
@@ -1120,7 +1128,8 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         chainAccountsList[0] = Accounts.ChainAccounts({
             chainId: 1,
             quarkStates: quarkStates_(address(0xa11ce), 12),
-            assetPositionsList: assetPositionsList
+            assetPositionsList: assetPositionsList,
+            cometPositions: emptyCometPositions_()
         });
 
         // Transfer max ETH to 0xceecee on chain 1
@@ -1229,7 +1238,8 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         chainAccountsList[0] = Accounts.ChainAccounts({
             chainId: 1,
             quarkStates: quarkStates_(address(0xa11ce), 12),
-            assetPositionsList: assetPositionsList
+            assetPositionsList: assetPositionsList,
+            cometPositions: emptyCometPositions_()
         });
 
         // Transfer 1.5ETH to 0xceecee on chain 1

--- a/test/builder/lib/Arrays.sol
+++ b/test/builder/lib/Arrays.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity ^0.8.23;
+
+library Arrays {
+    /* addressArray */
+    function addressArray(address address0) internal pure returns (address[] memory) {
+        address[] memory addresses = new address[](1);
+        addresses[0] = address0;
+        return addresses;
+    }
+
+    /* stringArray */
+    function stringArray(string memory string0) internal pure returns (string[] memory) {
+        string[] memory strings = new string[](1);
+        strings[0] = string0;
+        return strings;
+    }
+
+    function stringArray(string memory string0, string memory string1, string memory string2, string memory string3)
+        internal
+        pure
+        returns (string[] memory)
+    {
+        string[] memory strings = new string[](4);
+        strings[0] = string0;
+        strings[1] = string1;
+        strings[2] = string2;
+        strings[3] = string3;
+        return strings;
+    }
+
+    /* uintArray */
+    function uintArray(uint256 uint0) internal pure returns (uint256[] memory) {
+        uint256[] memory uints = new uint256[](1);
+        uints[0] = uint0;
+        return uints;
+    }
+
+    function uintArray(uint256 uint0, uint256 uint1, uint256 uint2, uint256 uint3)
+        internal
+        pure
+        returns (uint256[] memory)
+    {
+        uint256[] memory uints = new uint256[](4);
+        uints[0] = uint0;
+        uints[1] = uint1;
+        uints[2] = uint2;
+        uints[3] = uint3;
+        return uints;
+    }
+}

--- a/test/builder/lib/QuarkBuilderTest.sol
+++ b/test/builder/lib/QuarkBuilderTest.sol
@@ -100,8 +100,8 @@ contract QuarkBuilderTest {
         return chainAccountsList;
     }
 
-    function emptyCometPositions_() internal pure returns (Accounts.CometPosition[] memory) {
-        Accounts.CometPosition[] memory emptyCometPositions = new Accounts.CometPosition[](0);
+    function emptyCometPositions_() internal pure returns (Accounts.CometPositions[] memory) {
+        Accounts.CometPositions[] memory emptyCometPositions = new Accounts.CometPositions[](0);
         return emptyCometPositions;
     }
 
@@ -295,9 +295,9 @@ contract QuarkBuilderTest {
     function cometPositionsForCometPorfolios(uint256 chainId, address account, CometPortfolio[] memory cometPortfolios)
         internal
         pure
-        returns (Accounts.CometPosition[] memory)
+        returns (Accounts.CometPositions[] memory)
     {
-        Accounts.CometPosition[] memory cometPositions = new Accounts.CometPosition[](cometPortfolios.length);
+        Accounts.CometPositions[] memory cometPositions = new Accounts.CometPositions[](cometPortfolios.length);
 
         for (uint256 i = 0; i < cometPortfolios.length; ++i) {
             CometPortfolio memory cometPortfolio = cometPortfolios[i];
@@ -313,7 +313,7 @@ contract QuarkBuilderTest {
                 });
             }
 
-            cometPositions[i] = Accounts.CometPosition({
+            cometPositions[i] = Accounts.CometPositions({
                 comet: cometPortfolio.comet,
                 basePosition: Accounts.CometBasePosition({
                     asset: baseAssetForComet(chainId, cometPortfolio.comet),

--- a/test/builder/lib/QuarkBuilderTest.sol
+++ b/test/builder/lib/QuarkBuilderTest.sol
@@ -331,6 +331,8 @@ contract QuarkBuilderTest {
     function baseAssetForComet(uint256 chainId, address comet) internal pure returns (address) {
         if (comet == COMET_1_USDC || comet == COMET_8453_USDC) {
             return usdc_(chainId);
+        } else if (comet == COMET_1_WETH || comet == COMET_8453_WETH) {
+            return weth_(chainId);
         } else {
             revert("unknown chainId/comet combination");
         }

--- a/test/builder/lib/QuarkBuilderTest.sol
+++ b/test/builder/lib/QuarkBuilderTest.sol
@@ -321,7 +321,7 @@ contract QuarkBuilderTest {
                     borrowed: Arrays.uintArray(cometPortfolio.baseBorrowed),
                     supplied: Arrays.uintArray(cometPortfolio.baseSupplied)
                 }),
-                collaterals: collateralPositions
+                collateralPositions: collateralPositions
             });
         }
 

--- a/test/builder/lib/QuarkBuilderTest.sol
+++ b/test/builder/lib/QuarkBuilderTest.sol
@@ -11,10 +11,15 @@ import {PaymentInfo} from "src/builder/PaymentInfo.sol";
 import {QuarkBuilder} from "src/builder/QuarkBuilder.sol";
 import {Strings} from "src/builder/Strings.sol";
 
+import {Arrays} from "test/builder/lib/Arrays.sol";
+
 contract QuarkBuilderTest {
     uint256 constant BLOCK_TIMESTAMP = 123_456_789;
 
-    address constant COMET_1 = address(0xc3);
+    address constant COMET_1_USDC = address(0xc3010a);
+    address constant COMET_1_WETH = address(0xc3010b);
+    address constant COMET_8453_USDC = address(0xc384530a);
+    address constant COMET_8453_WETH = address(0xc384530b);
 
     address constant LINK_1 = address(0xfeed01);
     address constant LINK_7777 = address(0xfeed7777);
@@ -77,19 +82,27 @@ contract QuarkBuilderTest {
         chainAccountsList[0] = Accounts.ChainAccounts({
             chainId: 1,
             quarkStates: quarkStates_(address(0xa11ce), 12),
-            assetPositionsList: assetPositionsList_(1, address(0xa11ce), uint256(amount / 2))
+            assetPositionsList: assetPositionsList_(1, address(0xa11ce), uint256(amount / 2)),
+            cometPositions: emptyCometPositions_()
         });
         chainAccountsList[1] = Accounts.ChainAccounts({
             chainId: 8453,
             quarkStates: quarkStates_(address(0xb0b), 2),
-            assetPositionsList: assetPositionsList_(8453, address(0xb0b), uint256(amount / 2))
+            assetPositionsList: assetPositionsList_(8453, address(0xb0b), uint256(amount / 2)),
+            cometPositions: emptyCometPositions_()
         });
         chainAccountsList[2] = Accounts.ChainAccounts({
             chainId: 7777,
             quarkStates: quarkStates_(address(0xc0b), 5),
-            assetPositionsList: assetPositionsList_(7777, address(0xc0b), uint256(0))
+            assetPositionsList: assetPositionsList_(7777, address(0xc0b), uint256(0)),
+            cometPositions: emptyCometPositions_()
         });
         return chainAccountsList;
+    }
+
+    function emptyCometPositions_() internal pure returns (Accounts.CometPosition[] memory) {
+        Accounts.CometPosition[] memory emptyCometPositions = new Accounts.CometPosition[](0);
+        return emptyCometPositions;
     }
 
     function quarkStates_() internal pure returns (Accounts.QuarkState[] memory) {
@@ -197,6 +210,26 @@ contract QuarkBuilderTest {
         }
     }
 
+    function cometUsdc_(uint256 chainId) internal pure returns (address) {
+        if (chainId == 1) {
+            return COMET_1_USDC;
+        } else if (chainId == 8453) {
+            return COMET_8453_USDC;
+        } else {
+            revert("no USDC Comet for chain id");
+        }
+    }
+
+    function cometWeth_(uint256 chainId) internal pure returns (address) {
+        if (chainId == 1) {
+            return COMET_1_WETH;
+        } else if (chainId == 8453) {
+            return COMET_8453_WETH;
+        } else {
+            revert("no WETH Comet for chain id");
+        }
+    }
+
     function quarkStates_(address account, uint96 nextNonce) internal pure returns (Accounts.QuarkState[] memory) {
         Accounts.QuarkState[] memory quarkStates = new Accounts.QuarkState[](1);
         quarkStates[0] = quarkState_(account, nextNonce);
@@ -211,38 +244,26 @@ contract QuarkBuilderTest {
         return Accounts.QuarkState({account: account, quarkNextNonce: nextNonce});
     }
 
-    function stringArray(string memory string0, string memory string1, string memory string2, string memory string3)
-        internal
-        pure
-        returns (string[] memory)
-    {
-        string[] memory strings = new string[](4);
-        strings[0] = string0;
-        strings[1] = string1;
-        strings[2] = string2;
-        strings[3] = string3;
-        return strings;
-    }
-
-    function uintArray(uint256 uint0, uint256 uint1, uint256 uint2, uint256 uint3)
-        internal
-        pure
-        returns (uint256[] memory)
-    {
-        uint256[] memory uints = new uint256[](4);
-        uints[0] = uint0;
-        uints[1] = uint1;
-        uints[2] = uint2;
-        uints[3] = uint3;
-        return uints;
-    }
-
     struct ChainPortfolio {
         uint256 chainId;
         address account;
         uint96 nextNonce;
         string[] assetSymbols;
         uint256[] assetBalances;
+        CometPortfolio[] cometPortfolios;
+    }
+
+    struct CometPortfolio {
+        address comet;
+        uint256 baseSupplied;
+        uint256 baseBorrowed;
+        string[] collateralAssetSymbols;
+        uint256[] collateralAssetBalances;
+    }
+
+    function emptyCometPortfolios_() internal pure returns (CometPortfolio[] memory) {
+        CometPortfolio[] memory emptyCometPortfolios = new CometPortfolio[](0);
+        return emptyCometPortfolios;
     }
 
     function chainAccountsFromChainPortfolios(ChainPortfolio[] memory chainPortfolios)
@@ -260,11 +281,59 @@ contract QuarkBuilderTest {
                     chainPortfolios[i].account,
                     chainPortfolios[i].assetSymbols,
                     chainPortfolios[i].assetBalances
+                    ),
+                // cometPositions: cometPositionsFor
+                cometPositions: cometPositionsForCometPorfolios(
+                    chainPortfolios[i].chainId, chainPortfolios[i].account, chainPortfolios[i].cometPortfolios
                     )
             });
         }
 
         return chainAccountsList;
+    }
+
+    function cometPositionsForCometPorfolios(uint256 chainId, address account, CometPortfolio[] memory cometPortfolios)
+        internal
+        pure
+        returns (Accounts.CometPosition[] memory)
+    {
+        Accounts.CometPosition[] memory cometPositions = new Accounts.CometPosition[](cometPortfolios.length);
+
+        for (uint256 i = 0; i < cometPortfolios.length; ++i) {
+            CometPortfolio memory cometPortfolio = cometPortfolios[i];
+            Accounts.CometCollateralPosition[] memory collateralPositions =
+                new Accounts.CometCollateralPosition[](cometPortfolio.collateralAssetSymbols.length);
+
+            for (uint256 j = 0; j < cometPortfolio.collateralAssetSymbols.length; ++j) {
+                (address asset,,) = assetInfo(cometPortfolio.collateralAssetSymbols[j], chainId);
+                collateralPositions[j] = Accounts.CometCollateralPosition({
+                    asset: asset,
+                    accounts: Arrays.addressArray(account),
+                    balances: Arrays.uintArray(cometPortfolio.collateralAssetBalances[j])
+                });
+            }
+
+            cometPositions[i] = Accounts.CometPosition({
+                comet: cometPortfolio.comet,
+                basePosition: Accounts.CometBasePosition({
+                    asset: baseAssetForComet(chainId, cometPortfolio.comet),
+                    accounts: Arrays.addressArray(account),
+                    borrowed: Arrays.uintArray(cometPortfolio.baseBorrowed),
+                    supplied: Arrays.uintArray(cometPortfolio.baseSupplied)
+                }),
+                collaterals: collateralPositions
+            });
+        }
+
+        return cometPositions;
+    }
+
+    function baseAssetForComet(uint256 chainId, address comet) internal pure returns (address) {
+        if (comet == COMET_1_USDC || comet == COMET_8453_USDC) {
+            return usdc_(chainId);
+        } else {
+            revert("unknown chainId/comet combination");
+        }
     }
 
     function assetPositionsForAssets(


### PR DESCRIPTION
supporting "withdraw max" to `cometWithdraw` in QuarkBuilder.

supporting this feature requires that we add a representation of the caller's Comet positions, in order to know how much will be withdrawn, and therefore whether the caller has enough payment token to cover the cost of the transaction.