### PR TITLE
Hashmap helper lib to simplify the merge operation function

### DIFF
--- a/src/builder/HashMap.sol
+++ b/src/builder/HashMap.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: BSD-3-Clause
 pragma solidity 0.8.23;
 
 import {List} from "./List.sol";
@@ -21,7 +21,7 @@ library HashMap {
     }
 
     function get(Map memory map, bytes memory key) internal pure returns (bytes memory) {
-        for (uint256 i = 0; i < map.entries.length; i++) {
+        for (uint256 i = 0; i < map.entries.length; ++i) {
             Entry memory entry = abi.decode(List.get(map.entries, i), (Entry));
             if (keccak256(entry.key) == keccak256(key)) {
                 return entry.value;
@@ -31,7 +31,7 @@ library HashMap {
     }
 
     function contains(Map memory map, bytes memory key) internal pure returns (bool) {
-        for (uint256 i = 0; i < map.entries.length; i++) {
+        for (uint256 i = 0; i < map.entries.length; ++i) {
             Entry memory entry = abi.decode(List.get(map.entries, i), (Entry));
             if (keccak256(entry.key) == keccak256(key)) {
                 return true;
@@ -42,7 +42,7 @@ library HashMap {
 
     function put(Map memory map, bytes memory key, bytes memory value) internal pure returns (Map memory) {
         Entry memory newEntry = Entry({key: key, value: value});
-        for (uint256 i = 0; i < map.entries.length; i++) {
+        for (uint256 i = 0; i < map.entries.length; ++i) {
             Entry memory entry = abi.decode(List.get(map.entries, i), (Entry));
             if (keccak256(entry.key) == keccak256(key)) {
                 // Replace existing entry
@@ -56,7 +56,7 @@ library HashMap {
     }
 
     function remove(Map memory map, bytes memory key) internal pure returns (Map memory) {
-        for (uint256 i = 0; i < map.entries.length; i++) {
+        for (uint256 i = 0; i < map.entries.length; ++i) {
             Entry memory entry = abi.decode(List.get(map.entries, i), (Entry));
             if (keccak256(entry.key) == keccak256(key)) {
                 List.remove(map.entries, i);
@@ -68,7 +68,7 @@ library HashMap {
 
     function keys(Map memory map) internal pure returns (bytes[] memory) {
         bytes[] memory result = new bytes[](map.entries.length);
-        for (uint256 i = 0; i < map.entries.length; i++) {
+        for (uint256 i = 0; i < map.entries.length; ++i) {
             Entry memory entry = abi.decode(List.get(map.entries, i), (Entry));
             result[i] = entry.key;
         }
@@ -103,17 +103,17 @@ library HashMap {
     function keysUint256(Map memory map) internal pure returns (uint256[] memory) {
         bytes[] memory keysBytes = keys(map);
         uint256[] memory keysUint = new uint256[](keysBytes.length);
-        for (uint256 i = 0; i < keysBytes.length; i++) {
+        for (uint256 i = 0; i < keysBytes.length; ++i) {
             keysUint[i] = abi.decode(keysBytes[i], (uint256));
         }
         return keysUint;
     }
 
-    function getDynamicList(Map memory map, uint256 key) internal pure returns (List.DynamicArray memory) {
+    function getDynamicArray(Map memory map, uint256 key) internal pure returns (List.DynamicArray memory) {
         return abi.decode(get(map, abi.encode(key)), (List.DynamicArray));
     }
 
-    function putDynamicList(Map memory map, uint256 key, List.DynamicArray memory value)
+    function putDynamicArray(Map memory map, uint256 key, List.DynamicArray memory value)
         internal
         pure
         returns (Map memory)

--- a/src/builder/HashMap.sol
+++ b/src/builder/HashMap.sol
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.23;
+
+import {List} from "./List.sol";
+
+library HashMap {
+    error KeyNotFound();
+
+    struct Entry {
+        bytes key;
+        bytes value;
+    }
+
+    // NOTE: Now just use DynamicArray to help with Map use cases (could be optimized later)
+    struct Map {
+        List.DynamicArray entries;
+    }
+
+    function newMap() internal pure returns (Map memory) {
+        return Map(List.newList());
+    }
+
+    function get(Map memory map, bytes memory key) internal pure returns (bytes memory) {
+        for (uint256 i = 0; i < map.entries.length; i++) {
+            Entry memory entry = abi.decode(List.get(map.entries, i), (Entry));
+            if (keccak256(entry.key) == keccak256(key)) {
+                return entry.value;
+            }
+        }
+        revert KeyNotFound();
+    }
+
+    function contains(Map memory map, bytes memory key) internal pure returns (bool) {
+        for (uint256 i = 0; i < map.entries.length; i++) {
+            Entry memory entry = abi.decode(List.get(map.entries, i), (Entry));
+            if (keccak256(entry.key) == keccak256(key)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    function put(Map memory map, bytes memory key, bytes memory value) internal pure returns (Map memory) {
+        Entry memory newEntry = Entry({key: key, value: value});
+        for (uint256 i = 0; i < map.entries.length; i++) {
+            Entry memory entry = abi.decode(List.get(map.entries, i), (Entry));
+            if (keccak256(entry.key) == keccak256(key)) {
+                // Replace existing entry
+                map.entries.bytesArray[i] = abi.encode(newEntry);
+                return map;
+            }
+        }
+
+        List.addItem(map.entries, abi.encode(newEntry));
+        return map;
+    }
+
+    function remove(Map memory map, bytes memory key) internal pure returns (Map memory) {
+        for (uint256 i = 0; i < map.entries.length; i++) {
+            Entry memory entry = abi.decode(List.get(map.entries, i), (Entry));
+            if (keccak256(entry.key) == keccak256(key)) {
+                List.remove(map.entries, i);
+                return map;
+            }
+        }
+        revert KeyNotFound();
+    }
+
+    function keys(Map memory map) internal pure returns (bytes[] memory) {
+        bytes[] memory result = new bytes[](map.entries.length);
+        for (uint256 i = 0; i < map.entries.length; i++) {
+            Entry memory entry = abi.decode(List.get(map.entries, i), (Entry));
+            result[i] = entry.key;
+        }
+        return result;
+    }
+
+    // ========= Helper functions for common keys/values types =========
+    function get(Map memory map, uint256 key) internal pure returns (bytes memory) {
+        return get(map, abi.encode(key));
+    }
+
+    function contains(Map memory map, uint256 key) internal pure returns (bool) {
+        return contains(map, abi.encode(key));
+    }
+
+    function put(Map memory map, uint256 key, bytes memory value) internal pure returns (Map memory) {
+        return put(map, abi.encode(key), value);
+    }
+
+    function remove(Map memory map, uint256 key) internal pure returns (Map memory) {
+        return remove(map, abi.encode(key));
+    }
+
+    function getUint256(Map memory map, uint256 key) internal pure returns (uint256) {
+        return abi.decode(get(map, abi.encode(key)), (uint256));
+    }
+
+    function putUint256(Map memory map, uint256 key, uint256 value) internal pure returns (Map memory) {
+        return put(map, abi.encode(key), abi.encode(value));
+    }
+
+    function keysUint256(Map memory map) internal pure returns (uint256[] memory) {
+        bytes[] memory keysBytes = keys(map);
+        uint256[] memory keysUint = new uint256[](keysBytes.length);
+        for (uint256 i = 0; i < keysBytes.length; i++) {
+            keysUint[i] = abi.decode(keysBytes[i], (uint256));
+        }
+        return keysUint;
+    }
+
+    function getDynamicList(Map memory map, uint256 key) internal pure returns (List.DynamicArray memory) {
+        return abi.decode(get(map, abi.encode(key)), (List.DynamicArray));
+    }
+
+    function putDynamicList(Map memory map, uint256 key, List.DynamicArray memory value)
+        internal
+        pure
+        returns (Map memory)
+    {
+        return put(map, abi.encode(key), abi.encode(value));
+    }
+}

--- a/src/builder/List.sol
+++ b/src/builder/List.sol
@@ -24,7 +24,7 @@ library List {
         return result;
     }
 
-    function addItem(DynamicArray memory list, bytes memory item) internal pure {
+    function addItem(DynamicArray memory list, bytes memory item) internal pure returns (DynamicArray memory) {
         if (list.length >= list.bytesArray.length) {
             bytes[] memory newBytesArray = new bytes[](list.bytesArray.length * 2 + 1);
             for (uint256 i = 0; i < list.length; ++i) {
@@ -35,6 +35,7 @@ library List {
 
         list.bytesArray[list.length] = item;
         list.length++;
+        return list;
     }
 
     function get(DynamicArray memory list, uint256 index) internal pure returns (bytes memory) {
@@ -42,12 +43,37 @@ library List {
         return list.bytesArray[index];
     }
 
+    function remove(DynamicArray memory list, uint256 index) internal pure {
+        if (index >= list.length) revert IndexOutOfBound();
+        for (uint256 i = index; i < list.length - 1; ++i) {
+            list.bytesArray[i] = list.bytesArray[i + 1];
+        }
+        list.length--;
+    }
+
+    function indexOf(DynamicArray memory list, bytes memory item) internal pure returns (int256) {
+        for (uint256 i = 0; i < list.length; ++i) {
+            if (keccak256(list.bytesArray[i]) == keccak256(item)) {
+                return int256(i);
+            }
+        }
+        return -1;
+    }
+
+    function contains(DynamicArray memory list, bytes memory item) internal pure returns (bool) {
+        return indexOf(list, item) != -1;
+    }
+
     // Struct APIs
 
     // === QuarkOperations ===
 
-    function addQuarkOperation(DynamicArray memory list, IQuarkWallet.QuarkOperation memory operation) internal pure {
-        addItem(list, abi.encode(operation));
+    function addQuarkOperation(DynamicArray memory list, IQuarkWallet.QuarkOperation memory operation)
+        internal
+        pure
+        returns (DynamicArray memory)
+    {
+        return addItem(list, abi.encode(operation));
     }
 
     function getQuarkOperation(DynamicArray memory list, uint256 index)
@@ -70,10 +96,26 @@ library List {
         return result;
     }
 
+    function indexOf(DynamicArray memory list, IQuarkWallet.QuarkOperation memory item)
+        internal
+        pure
+        returns (int256)
+    {
+        return indexOf(list, abi.encode(item));
+    }
+
+    function contains(DynamicArray memory list, IQuarkWallet.QuarkOperation memory item) internal pure returns (bool) {
+        return contains(list, abi.encode(item));
+    }
+
     // === Action ===
 
-    function addAction(DynamicArray memory list, Actions.Action memory action) internal pure {
-        addItem(list, abi.encode(action));
+    function addAction(DynamicArray memory list, Actions.Action memory action)
+        internal
+        pure
+        returns (DynamicArray memory)
+    {
+        return addItem(list, abi.encode(action));
     }
 
     function getAction(DynamicArray memory list, uint256 index) internal pure returns (Actions.Action memory) {
@@ -86,5 +128,13 @@ library List {
             result[i] = abi.decode(list.bytesArray[i], (Actions.Action));
         }
         return result;
+    }
+
+    function indexOf(DynamicArray memory list, Actions.Action memory action) internal pure returns (int256) {
+        return indexOf(list, abi.encode(action));
+    }
+
+    function contains(DynamicArray memory list, Actions.Action memory action) internal pure returns (bool) {
+        return contains(list, abi.encode(action));
     }
 }

--- a/src/builder/QuarkOperationHelper.sol
+++ b/src/builder/QuarkOperationHelper.sol
@@ -35,19 +35,19 @@ library QuarkOperationHelper {
         for (uint256 i = 0; i < quarkOperations.length; ++i) {
             uint256 chainId = actions[i].chainId;
             if (!HashMap.contains(groupedQuarkOperations, chainId)) {
-                HashMap.putDynamicList(groupedQuarkOperations, chainId, List.newList());
+                HashMap.putDynamicArray(groupedQuarkOperations, chainId, List.newList());
             }
             if (!HashMap.contains(groupedActions, chainId)) {
-                HashMap.putDynamicList(groupedActions, chainId, List.newList());
+                HashMap.putDynamicArray(groupedActions, chainId, List.newList());
             }
 
-            HashMap.putDynamicList(
+            HashMap.putDynamicArray(
                 groupedQuarkOperations,
                 chainId,
-                List.addQuarkOperation(HashMap.getDynamicList(groupedQuarkOperations, chainId), quarkOperations[i])
+                List.addQuarkOperation(HashMap.getDynamicArray(groupedQuarkOperations, chainId), quarkOperations[i])
             );
-            HashMap.putDynamicList(
-                groupedActions, chainId, List.addAction(HashMap.getDynamicList(groupedActions, chainId), actions[i])
+            HashMap.putDynamicArray(
+                groupedActions, chainId, List.addAction(HashMap.getDynamicArray(groupedActions, chainId), actions[i])
             );
         }
 
@@ -60,8 +60,8 @@ library QuarkOperationHelper {
         // Merge operations for each unique chain
         for (uint256 i = 0; i < uniqueChainCount; ++i) {
             List.DynamicArray memory groupedQuarkOperationsList =
-                HashMap.getDynamicList(groupedQuarkOperations, chainIds[i]);
-            List.DynamicArray memory groupedActionsList = HashMap.getDynamicList(groupedActions, chainIds[i]);
+                HashMap.getDynamicArray(groupedQuarkOperations, chainIds[i]);
+            List.DynamicArray memory groupedActionsList = HashMap.getDynamicArray(groupedActions, chainIds[i]);
             if (groupedQuarkOperationsList.length == 1) {
                 // If there's only one operation for this chain, we don't need to merge
                 mergedQuarkOperations[i] = List.getQuarkOperation(groupedQuarkOperationsList, 0);


### PR DESCRIPTION
Hashmap helper lib to abstract away the need of using multiple array to track on unique ids. To give us somewhat an ability to use basic mapping functionality while in pure environment.