### PR TITLE
CometRepay max, v2

### DIFF
--- a/src/builder/Accounts.sol
+++ b/src/builder/Accounts.sol
@@ -239,4 +239,18 @@ library Accounts {
         }
         return result;
     }
+
+    function totalBorrowForAccount(
+        Accounts.ChainAccounts[] memory chainAccountsList,
+        uint256 chainId,
+        address comet,
+        address account
+    ) internal pure returns (uint256 totalBorrow) {
+        Accounts.CometPositions memory cometPositions = Accounts.findCometPositions(chainId, comet, chainAccountsList);
+        for (uint256 i = 0; i < cometPositions.basePosition.accounts.length; ++i) {
+            if (cometPositions.basePosition.accounts[i] == account) {
+                totalBorrow = cometPositions.basePosition.borrowed[i];
+            }
+        }
+    }
 }

--- a/src/builder/QuarkBuilder.sol
+++ b/src/builder/QuarkBuilder.sol
@@ -1197,11 +1197,10 @@ contract QuarkBuilder {
                 Actions.RepayActionContext memory cometRepayActionContext =
                     abi.decode(nonBridgeAction.actionContext, (Actions.RepayActionContext));
                 if (Strings.stringEqIgnoreCase(cometRepayActionContext.assetSymbol, paymentTokenSymbol)) {
-                    // weird variable placement to avoid stack-too-deep error
-                    uint256 repayAmount = cometRepayMaxAmount(
-                        chainAccountsList, cometRepayActionContext.chainId, cometRepayActionContext.comet, account
-                    );
                     if (cometRepayActionContext.amount == type(uint256).max) {
+                        uint256 repayAmount = cometRepayMaxAmount(
+                            chainAccountsList, cometRepayActionContext.chainId, cometRepayActionContext.comet, account
+                        );
                         paymentTokenCost += repayAmount;
                     } else {
                         paymentTokenCost += cometRepayActionContext.amount;

--- a/src/builder/QuarkBuilder.sol
+++ b/src/builder/QuarkBuilder.sol
@@ -19,7 +19,7 @@ import {List} from "./List.sol";
 contract QuarkBuilder {
     /* ===== Constants ===== */
 
-    string constant VERSION = "0.0.3";
+    string constant VERSION = "0.0.4";
 
     /* ===== Custom Errors ===== */
 
@@ -86,7 +86,7 @@ contract QuarkBuilder {
         // XXX confirm that the user is not withdrawing beyond their limits
 
         bool isMaxRepay = repayIntent.amount == type(uint256).max;
-        bool useQuotecall = false;
+        bool useQuotecall = false; // never use Quotecall
 
         uint256 repayAmount;
         if (isMaxRepay) {
@@ -1228,6 +1228,7 @@ contract QuarkBuilder {
                 Strings.stringEqIgnoreCase(nonBridgeAction.actionType, Actions.ACTION_TYPE_UNWRAP)
                     || Strings.stringEqIgnoreCase(nonBridgeAction.actionType, Actions.ACTION_TYPE_WRAP)
             ) {
+                // XXX test that wrapping/unwrapping impacts paymentTokenCost
                 Actions.WrapOrUnwrapActionContext memory wrapOrUnwrapActionContext =
                     abi.decode(nonBridgeAction.actionContext, (Actions.WrapOrUnwrapActionContext));
                 if (Strings.stringEqIgnoreCase(wrapOrUnwrapActionContext.fromAssetSymbol, paymentTokenSymbol)) {

--- a/src/builder/QuarkBuilder.sol
+++ b/src/builder/QuarkBuilder.sol
@@ -63,6 +63,17 @@ contract QuarkBuilder {
         address repayer;
     }
 
+    function cometRepayMaxAmount(
+        Accounts.ChainAccounts[] memory chainAccountsList,
+        uint256 chainId,
+        address comet,
+        address repayer
+    ) internal pure returns (uint256) {
+        uint256 totalBorrowForAccount = Accounts.totalBorrowForAccount(chainAccountsList, chainId, comet, repayer);
+        uint256 buffer = totalBorrowForAccount / 1000; // 0.1%
+        return totalBorrowForAccount + buffer;
+    }
+
     function cometRepay(
         CometRepayIntent memory repayIntent,
         Accounts.ChainAccounts[] memory chainAccountsList,
@@ -74,22 +85,25 @@ contract QuarkBuilder {
 
         // XXX confirm that the user is not withdrawing beyond their limits
 
-        assertFundsAvailable(
-            repayIntent.chainId, repayIntent.assetSymbol, repayIntent.amount, chainAccountsList, payment
-        );
+        bool isMaxRepay = repayIntent.amount == type(uint256).max;
+        bool useQuotecall = false;
+
+        uint256 repayAmount;
+        if (isMaxRepay) {
+            repayAmount =
+                cometRepayMaxAmount(chainAccountsList, repayIntent.chainId, repayIntent.comet, repayIntent.repayer);
+        } else {
+            repayAmount = repayIntent.amount;
+        }
+
+        assertFundsAvailable(repayIntent.chainId, repayIntent.assetSymbol, repayAmount, chainAccountsList, payment);
 
         List.DynamicArray memory actions = List.newList();
         List.DynamicArray memory quarkOperations = List.newList();
 
-        bool useQuotecall = false; // TODO: calculate an actual value for useQuoteCall
-
-        if (
-            needsBridgedFunds(
-                repayIntent.assetSymbol, repayIntent.amount, repayIntent.chainId, chainAccountsList, payment
-            )
-        ) {
+        if (needsBridgedFunds(repayIntent.assetSymbol, repayAmount, repayIntent.chainId, chainAccountsList, payment)) {
             // Note: Assumes that the asset uses the same # of decimals on each chain
-            uint256 amountNeededOnDst = repayIntent.amount;
+            uint256 amountNeededOnDst = repayAmount;
             // If action is paid for with tokens and the payment token is the
             // repay token, we need to add the max cost to the
             // amountNeededOnDst for target chain
@@ -123,7 +137,7 @@ contract QuarkBuilder {
             chainAccountsList,
             payment,
             repayIntent.assetSymbol,
-            repayIntent.amount,
+            repayAmount,
             repayIntent.chainId,
             repayIntent.repayer,
             repayIntent.blockTimestamp,
@@ -165,7 +179,11 @@ contract QuarkBuilder {
             }
 
             assertSufficientPaymentTokenBalances(
-                actionsArray, chainAccountsList, repayIntent.chainId, supplementalPaymentTokenBalance
+                actionsArray,
+                chainAccountsList,
+                repayIntent.chainId,
+                repayIntent.repayer,
+                supplementalPaymentTokenBalance
             );
         }
 
@@ -213,7 +231,7 @@ contract QuarkBuilder {
         List.DynamicArray memory actions = List.newList();
         List.DynamicArray memory quarkOperations = List.newList();
 
-        bool useQuotecall = false; // TODO: calculate an actual value for useQuoteCall
+        bool useQuotecall = false; // never use Quotecall
         bool paymentTokenIsCollateralAsset = false;
 
         for (uint256 i = 0; i < borrowIntent.collateralAssetSymbols.length; ++i) {
@@ -337,7 +355,11 @@ contract QuarkBuilder {
             }
 
             assertSufficientPaymentTokenBalances(
-                actionsArray, chainAccountsList, borrowIntent.chainId, supplementalPaymentTokenBalance
+                actionsArray,
+                chainAccountsList,
+                borrowIntent.chainId,
+                borrowIntent.borrower,
+                supplementalPaymentTokenBalance
             );
         }
 
@@ -370,7 +392,6 @@ contract QuarkBuilder {
         address sender;
     }
 
-    // TODO: handle supply max
     function cometSupply(
         CometSupplyIntent memory cometSupplyIntent,
         Accounts.ChainAccounts[] memory chainAccountsList,
@@ -389,8 +410,7 @@ contract QuarkBuilder {
             payment
         );
 
-        // TODO: set this properly
-        bool useQuotecall = false;
+        bool useQuotecall = false; // never use Quotecall
         List.DynamicArray memory actions = List.newList();
         List.DynamicArray memory quarkOperations = List.newList();
 
@@ -469,7 +489,9 @@ contract QuarkBuilder {
 
         // Validate generated actions for affordability
         if (payment.isToken) {
-            assertSufficientPaymentTokenBalances(actionsArray, chainAccountsList, cometSupplyIntent.chainId);
+            assertSufficientPaymentTokenBalances(
+                actionsArray, chainAccountsList, cometSupplyIntent.chainId, cometSupplyIntent.sender
+            );
         }
 
         // Merge operations that are from the same chain into one Multicall operation
@@ -593,7 +615,11 @@ contract QuarkBuilder {
             }
 
             assertSufficientPaymentTokenBalances(
-                actionsArray, chainAccountsList, cometWithdrawIntent.chainId, supplementalPaymentTokenBalance
+                actionsArray,
+                chainAccountsList,
+                cometWithdrawIntent.chainId,
+                cometWithdrawIntent.withdrawer,
+                supplementalPaymentTokenBalance
             );
         }
 
@@ -755,7 +781,9 @@ contract QuarkBuilder {
 
         // Validate generated actions for affordability
         if (payment.isToken) {
-            assertSufficientPaymentTokenBalances(actionsArray, chainAccountsList, transferIntent.chainId);
+            assertSufficientPaymentTokenBalances(
+                actionsArray, chainAccountsList, transferIntent.chainId, transferIntent.sender
+            );
         }
 
         // Merge operations that are from the same chain into one Multicall operation
@@ -916,7 +944,7 @@ contract QuarkBuilder {
         IQuarkWallet.QuarkOperation[] memory quarkOperationsArray = List.toQuarkOperationArray(quarkOperations);
         // Validate generated actions for affordability
         if (payment.isToken) {
-            assertSufficientPaymentTokenBalances(actionsArray, chainAccountsList, swapIntent.chainId);
+            assertSufficientPaymentTokenBalances(actionsArray, chainAccountsList, swapIntent.chainId, swapIntent.sender);
         }
 
         // Merge operations that are from the same chain into one Multicall operation
@@ -1109,15 +1137,17 @@ contract QuarkBuilder {
     function assertSufficientPaymentTokenBalances(
         Actions.Action[] memory actions,
         Accounts.ChainAccounts[] memory chainAccountsList,
-        uint256 targetChainId
+        uint256 targetChainId,
+        address account
     ) internal pure {
-        return assertSufficientPaymentTokenBalances(actions, chainAccountsList, targetChainId, 0);
+        return assertSufficientPaymentTokenBalances(actions, chainAccountsList, targetChainId, account, 0);
     }
 
     function assertSufficientPaymentTokenBalances(
         Actions.Action[] memory actions,
         Accounts.ChainAccounts[] memory chainAccountsList,
         uint256 targetChainId,
+        address account,
         uint256 supplementalPaymentTokenBalance
     ) internal pure {
         Actions.Action[] memory bridgeActions = Actions.findActionsOfType(actions, Actions.ACTION_TYPE_BRIDGE);
@@ -1167,7 +1197,15 @@ contract QuarkBuilder {
                 Actions.RepayActionContext memory cometRepayActionContext =
                     abi.decode(nonBridgeAction.actionContext, (Actions.RepayActionContext));
                 if (Strings.stringEqIgnoreCase(cometRepayActionContext.assetSymbol, paymentTokenSymbol)) {
-                    paymentTokenCost += cometRepayActionContext.amount;
+                    // weird variable placement to avoid stack-too-deep error
+                    uint256 repayAmount = cometRepayMaxAmount(
+                        chainAccountsList, cometRepayActionContext.chainId, cometRepayActionContext.comet, account
+                    );
+                    if (cometRepayActionContext.amount == type(uint256).max) {
+                        paymentTokenCost += repayAmount;
+                    } else {
+                        paymentTokenCost += cometRepayActionContext.amount;
+                    }
                 }
             } else if (Strings.stringEqIgnoreCase(nonBridgeAction.actionType, Actions.ACTION_TYPE_SUPPLY)) {
                 Actions.SupplyActionContext memory cometSupplyActionContext =

--- a/test/builder/QuarkBuilderCometRepay.t.sol
+++ b/test/builder/QuarkBuilderCometRepay.t.sol
@@ -11,18 +11,19 @@ import {Actions} from "src/builder/Actions.sol";
 import {CCTPBridgeActions} from "src/BridgeScripts.sol";
 import {CodeJarHelper} from "src/builder/CodeJarHelper.sol";
 import {CometRepayAndWithdrawMultipleAssets} from "src/DeFiScripts.sol";
+import {Multicall} from "src/Multicall.sol";
 import {Paycall} from "src/Paycall.sol";
 import {Strings} from "src/builder/Strings.sol";
-import {Multicall} from "src/Multicall.sol";
 import {WrapperActions} from "src/WrapperScripts.sol";
 
 contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
     function repayIntent_(
-        uint256 amount,
-        string memory assetSymbol,
         uint256 chainId,
-        uint256[] memory collateralAmounts,
-        string[] memory collateralAssetSymbols
+        address comet,
+        string memory assetSymbol,
+        uint256 amount,
+        string[] memory collateralAssetSymbols,
+        uint256[] memory collateralAmounts
     ) internal pure returns (QuarkBuilder.CometRepayIntent memory) {
         return QuarkBuilder.CometRepayIntent({
             amount: amount,
@@ -31,7 +32,7 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
             chainId: chainId,
             collateralAmounts: collateralAmounts,
             collateralAssetSymbols: collateralAssetSymbols,
-            comet: cometUsdc_(1),
+            comet: comet,
             repayer: address(0xa11ce)
         });
     }
@@ -49,7 +50,7 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
         vm.expectRevert(QuarkBuilder.InvalidInput.selector);
 
         builder.cometRepay(
-            repayIntent_(1e6, "USDC", 1, collateralAmounts, collateralAssetSymbols),
+            repayIntent_(1, cometUsdc_(1), "USDC", 1e6, collateralAssetSymbols, collateralAmounts),
             chainAccountsList_(3e6),
             paymentUsd_()
         );
@@ -64,7 +65,7 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
         vm.expectRevert(abi.encodeWithSelector(QuarkBuilder.FundsUnavailable.selector, "USDC", 1e6, 0));
 
         builder.cometRepay(
-            repayIntent_(1e6, "USDC", 1, collateralAmounts, collateralAssetSymbols), // attempting to repay 1 USDC
+            repayIntent_(1, cometUsdc_(1), "USDC", 1e6, collateralAssetSymbols, collateralAmounts), // attempting to repay 1 USDC
             chainAccountsList_(0e6), // but user has 0 USDC
             paymentUsd_()
         );
@@ -91,7 +92,7 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
         vm.expectRevert(QuarkBuilder.MaxCostTooHigh.selector);
 
         builder.cometRepay(
-            repayIntent_(1e18, "WETH", 1, collateralAmounts, collateralAssetSymbols),
+            repayIntent_(1, cometWeth_(1), "WETH", 1e18, collateralAssetSymbols, collateralAmounts),
             chainAccountsFromChainPortfolios(chainPortfolios),
             paymentUsdc_(maxCosts)
         );
@@ -125,11 +126,12 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
         QuarkBuilder builder = new QuarkBuilder();
         QuarkBuilder.BuilderResult memory result = builder.cometRepay(
             repayIntent_(
-                1e6, // repaying 1 USDC
-                "USDC",
                 1,
-                collateralAmounts, // withdrawing 1 LINK
-                collateralAssetSymbols
+                cometUsdc_(1),
+                "USDC",
+                1e6, // repaying 1 USDC
+                collateralAssetSymbols,
+                collateralAmounts // withdrawing 1 LINK
             ),
             chainAccountsFromChainPortfolios(chainPortfolios),
             paymentUsd_()
@@ -246,11 +248,12 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
         QuarkBuilder builder = new QuarkBuilder();
         QuarkBuilder.BuilderResult memory result = builder.cometRepay(
             repayIntent_(
-                1e18, // repaying 1 WETH
-                "WETH",
                 1,
-                collateralAmounts, // withdrawing 1 LINK
-                collateralAssetSymbols
+                cometWeth_(1),
+                "WETH",
+                1e18, // repaying 1 WETH
+                collateralAssetSymbols,
+                collateralAmounts // withdrawing 1 LINK
             ),
             chainAccountsFromChainPortfolios(chainPortfolios),
             paymentUsd_()
@@ -277,13 +280,13 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
             abi.encodeWithSelector(WrapperActions.wrapETH.selector, 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, 1e18);
         callDatas[1] = abi.encodeCall(
             CometRepayAndWithdrawMultipleAssets.run,
-            (cometUsdc_(1), collateralTokens, collateralAmounts, weth_(1), 1e18)
+            (cometWeth_(1), collateralTokens, collateralAmounts, weth_(1), 1e18)
         );
 
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-            "calldata is Multicall.run([wrapperActionsAddress, cometRepayAndWithdrawMultipleAssetsAddress], [WrapperActions.wrapWETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, 1e18), CometRepayAndWithdrawMultipleAssets.run(COMET_1, collateralTokens, collateralAmounts, weth_(1), 1e18)"
+            "calldata is Multicall.run([wrapperActionsAddress, cometRepayAndWithdrawMultipleAssetsAddress], [WrapperActions.wrapWETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, 1e18), CometRepayAndWithdrawMultipleAssets.run(COMET_1_WETH, collateralTokens, collateralAmounts, weth_(1), 1e18)"
         );
         assertEq(result.quarkOperations[0].scriptSources.length, 3);
         assertEq(result.quarkOperations[0].scriptSources[0], type(WrapperActions).creationCode);
@@ -312,7 +315,7 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
                     collateralAssetSymbols: collateralAssetSymbols,
                     collateralTokenPrices: collateralTokenPrices,
                     collateralTokens: collateralTokens,
-                    comet: cometUsdc_(1),
+                    comet: cometWeth_(1),
                     price: WETH_PRICE,
                     token: weth_(1)
                 })
@@ -357,11 +360,12 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
         QuarkBuilder builder = new QuarkBuilder();
         QuarkBuilder.BuilderResult memory result = builder.cometRepay(
             repayIntent_(
-                1e6, // repaying 1 USDC
-                "USDC",
                 1,
-                collateralAmounts, // withdrawing 1 LINK
-                collateralAssetSymbols
+                cometUsdc_(1),
+                "USDC",
+                1e6, // repaying 1 USDC
+                collateralAssetSymbols,
+                collateralAmounts // withdrawing 1 LINK
             ),
             chainAccountsFromChainPortfolios(chainPortfolios),
             paymentUsdc_(maxCosts) // and paying with USDC
@@ -480,11 +484,12 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
 
         QuarkBuilder.BuilderResult memory result = builder.cometRepay(
             repayIntent_(
-                1e18, // repaying 1 WETH
-                "WETH",
                 1,
-                collateralAmounts, // and withdrawing 1 USDC
-                collateralAssetSymbols
+                cometWeth_(1),
+                "WETH",
+                1e18, // repaying 1 WETH
+                collateralAssetSymbols,
+                collateralAmounts // and withdrawing 1 USDC
             ),
             chainAccountsFromChainPortfolios(chainPortfolios),
             paymentUsdc_(maxCosts) // user is paying with USDC that is currently supplied as collateral
@@ -513,7 +518,7 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
                 cometRepayAndWithdrawMultipleAssetsAddress,
                 abi.encodeWithSelector(
                     CometRepayAndWithdrawMultipleAssets.run.selector,
-                    cometUsdc_(1),
+                    cometWeth_(1),
                     collateralTokens,
                     collateralAmounts,
                     weth_(1),
@@ -521,7 +526,7 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
                 ),
                 0.5e6
             ),
-            "calldata is Paycall.run(CometRepayAndWithdrawMultipleAssets.run(cometUsdc_(1), [USDC_1], [1e6], WETH_1, 1e18), 0.5e6);"
+            "calldata is Paycall.run(CometRepayAndWithdrawMultipleAssets.run(cometWeth_(1), [USDC_1], [1e6], WETH_1, 1e18), 0.5e6);"
         );
 
         assertEq(result.quarkOperations[0].scriptSources.length, 2);
@@ -557,7 +562,7 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
                     collateralAssetSymbols: collateralAssetSymbols,
                     collateralTokenPrices: collateralTokenPrices,
                     collateralTokens: collateralTokens,
-                    comet: cometUsdc_(1),
+                    comet: cometWeth_(1),
                     price: WETH_PRICE,
                     token: weth_(1)
                 })
@@ -604,11 +609,12 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
 
         QuarkBuilder.BuilderResult memory result = builder.cometRepay(
             repayIntent_(
-                2e6,
-                "USDC", // repaying 2 USDC, bridged from mainnet to base
                 8453,
-                collateralAmounts,
-                collateralAssetSymbols
+                cometUsdc_(8453),
+                "USDC", // repaying 2 USDC, bridged from mainnet to base
+                2e6,
+                collateralAssetSymbols,
+                collateralAmounts
             ),
             chainAccountsFromChainPortfolios(chainPortfolios),
             paymentUsdc_(maxCosts)
@@ -674,7 +680,7 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
                 cometRepayAndWithdrawMultipleAssetsAddress,
                 abi.encodeWithSelector(
                     CometRepayAndWithdrawMultipleAssets.run.selector,
-                    cometUsdc_(1),
+                    cometUsdc_(8453),
                     collateralTokens,
                     collateralAmounts,
                     usdc_(8453),
@@ -682,7 +688,7 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
                 ),
                 0.2e6
             ),
-            "calldata is Paycall.run(CometRepayAndWithdrawMultipleAssets.run(cometUsdc_(1), [LINK_8453], [1e18], USDC_8453, 2e6), 0.2e6);"
+            "calldata is Paycall.run(CometRepayAndWithdrawMultipleAssets.run(cometUsdc_(8453), [LINK_8453], [1e18], USDC_8453, 2e6), 0.2e6);"
         );
         assertEq(result.quarkOperations[1].scriptSources.length, 2);
         assertEq(result.quarkOperations[1].scriptSources[0], type(CometRepayAndWithdrawMultipleAssets).creationCode);
@@ -714,7 +720,7 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
                     destinationChainId: 8453,
                     price: USDC_PRICE,
                     recipient: address(0xa11ce),
-                    token: USDC_1
+                    token: usdc_(1)
                 })
             ),
             "action context encoded from BridgeActionContext"
@@ -741,7 +747,318 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
                     collateralAssetSymbols: collateralAssetSymbols,
                     collateralTokenPrices: collateralTokenPrices,
                     collateralTokens: collateralTokens,
+                    comet: cometUsdc_(8453),
+                    price: USDC_PRICE,
+                    token: usdc_(8453)
+                })
+            ),
+            "action context encoded from RepayActionContext"
+        );
+
+        // TODO: Check the contents of the EIP712 data
+        assertNotEq(result.eip712Data.digest, hex"", "non-empty digest");
+        assertNotEq(result.eip712Data.domainSeparator, hex"", "non-empty domain separator");
+        assertNotEq(result.eip712Data.hashStruct, hex"", "non-empty hashStruct");
+    }
+
+    function testCometRepayMax() public {
+        PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](1);
+        maxCosts[0] = PaymentInfo.PaymentMaxCost({chainId: 1, amount: 0.1e6});
+
+        address[] memory collateralTokens = new address[](0);
+        uint256[] memory collateralAmounts = new uint256[](0);
+        string[] memory collateralAssetSymbols = new string[](0);
+
+        CometPortfolio[] memory cometPortfolios = new CometPortfolio[](1);
+        cometPortfolios[0] = CometPortfolio({
+            comet: cometUsdc_(1),
+            baseSupplied: 0,
+            baseBorrowed: 10e6, // currently borrowing 10 USDC
+            collateralAssetSymbols: Arrays.stringArray("LINK"),
+            collateralAssetBalances: Arrays.uintArray(0)
+        });
+
+        ChainPortfolio[] memory chainPortfolios = new ChainPortfolio[](1);
+        chainPortfolios[0] = ChainPortfolio({
+            chainId: 1,
+            account: address(0xa11ce),
+            nextNonce: 12,
+            assetSymbols: Arrays.stringArray("USDC", "USDT", "LINK", "WETH"),
+            assetBalances: Arrays.uintArray(50e6, 0, 0, 0), // has 50 USDC
+            cometPortfolios: cometPortfolios
+        });
+
+        QuarkBuilder builder = new QuarkBuilder();
+        QuarkBuilder.BuilderResult memory result = builder.cometRepay(
+            repayIntent_(
+                1,
+                cometUsdc_(1),
+                "USDC",
+                type(uint256).max, // repaying max (all 10 USDC)
+                collateralAssetSymbols,
+                collateralAmounts
+            ),
+            chainAccountsFromChainPortfolios(chainPortfolios),
+            paymentUsdc_(maxCosts)
+        );
+
+        assertEq(result.paymentCurrency, "usdc", "usdc currency");
+
+        address paycallAddress = CodeJarHelper.getCodeAddress(
+            abi.encodePacked(type(Paycall).creationCode, abi.encode(ETH_USD_PRICE_FEED_1, USDC_1))
+        );
+        address cometRepayAndWithdrawMultipleAssetsAddress =
+            CodeJarHelper.getCodeAddress(type(CometRepayAndWithdrawMultipleAssets).creationCode);
+
+        // Check the quark operations
+        assertEq(result.quarkOperations.length, 1, "one operation");
+        assertEq(
+            result.quarkOperations[0].scriptAddress,
+            paycallAddress,
+            "script address is correct given the code jar address on mainnet"
+        );
+
+        assertEq(
+            result.quarkOperations[0].scriptCalldata,
+            abi.encodeWithSelector(
+                Paycall.run.selector,
+                cometRepayAndWithdrawMultipleAssetsAddress,
+                abi.encodeWithSelector(
+                    CometRepayAndWithdrawMultipleAssets.run.selector,
+                    cometUsdc_(1),
+                    collateralTokens,
+                    collateralAmounts,
+                    usdc_(1),
+                    type(uint256).max
+                ),
+                0.1e6
+            ),
+            "calldata is Paycall.run(CometRepayAndWithdrawMultipleAssets.run(cometUsdc_(1), [], [], USDC_1, uint256.max), 0.1e6);"
+        );
+
+        assertEq(result.quarkOperations[0].scriptSources.length, 2);
+        assertEq(result.quarkOperations[0].scriptSources[0], type(CometRepayAndWithdrawMultipleAssets).creationCode);
+        assertEq(
+            result.quarkOperations[0].scriptSources[1],
+            abi.encodePacked(type(Paycall).creationCode, abi.encode(ETH_USD_PRICE_FEED_1, USDC_1))
+        );
+        assertEq(
+            result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
+        );
+
+        // check the actions
+        assertEq(result.actions.length, 1, "one action");
+        assertEq(result.actions[0].chainId, 1, "operation is on chainid 1");
+        assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
+        assertEq(result.actions[0].actionType, "REPAY", "action type is 'REPAY'");
+        assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
+        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC on mainnet");
+        assertEq(result.actions[0].paymentMaxCost, 0.1e6, "payment should have max cost of 0.1e6");
+
+        uint256[] memory collateralTokenPrices = new uint256[](0);
+
+        assertEq(
+            result.actions[0].actionContext,
+            abi.encode(
+                Actions.RepayActionContext({
+                    amount: type(uint256).max,
+                    assetSymbol: "USDC",
+                    chainId: 1,
+                    collateralAmounts: collateralAmounts,
+                    collateralAssetSymbols: collateralAssetSymbols,
+                    collateralTokenPrices: collateralTokenPrices,
+                    collateralTokens: collateralTokens,
                     comet: cometUsdc_(1),
+                    price: USDC_PRICE,
+                    token: usdc_(1)
+                })
+            ),
+            "action context encoded from RepayActionContext"
+        );
+
+        // TODO: Check the contents of the EIP712 data
+        assertNotEq(result.eip712Data.digest, hex"", "non-empty digest");
+        assertNotEq(result.eip712Data.domainSeparator, hex"", "non-empty domain separator");
+        assertNotEq(result.eip712Data.hashStruct, hex"", "non-empty hashStruct");
+    }
+
+    function testCometRepayMaxWithBridge() public {
+        PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](2);
+        maxCosts[0] = PaymentInfo.PaymentMaxCost({chainId: 1, amount: 0.1e6});
+        maxCosts[1] = PaymentInfo.PaymentMaxCost({chainId: 8453, amount: 0.1e6});
+
+        address[] memory collateralTokens = new address[](0);
+        uint256[] memory collateralAmounts = new uint256[](0);
+        string[] memory collateralAssetSymbols = new string[](0);
+
+        CometPortfolio[] memory cometPortfolios = new CometPortfolio[](1);
+        cometPortfolios[0] = CometPortfolio({
+            comet: cometUsdc_(8453),
+            baseSupplied: 0,
+            baseBorrowed: 10e6, // currently borrowing 10 USDC on Base Comet
+            collateralAssetSymbols: Arrays.stringArray("LINK"),
+            collateralAssetBalances: Arrays.uintArray(0)
+        });
+
+        ChainPortfolio[] memory chainPortfolios = new ChainPortfolio[](2);
+        chainPortfolios[0] = ChainPortfolio({
+            chainId: 1,
+            account: address(0xa11ce),
+            nextNonce: 12,
+            assetSymbols: Arrays.stringArray("USDC", "USDT", "LINK", "WETH"),
+            assetBalances: Arrays.uintArray(50e6, 0, 0, 0), // has 50 USDC on mainnet
+            cometPortfolios: emptyCometPortfolios_()
+        });
+        chainPortfolios[1] = ChainPortfolio({
+            chainId: 8453,
+            account: address(0xa11ce),
+            nextNonce: 12,
+            assetSymbols: Arrays.stringArray("USDC", "USDT", "LINK", "WETH"),
+            assetBalances: Arrays.uintArray(0, 0, 0, 0), // has 0 USDC on base
+            cometPortfolios: cometPortfolios
+        });
+
+        QuarkBuilder builder = new QuarkBuilder();
+        QuarkBuilder.BuilderResult memory result = builder.cometRepay(
+            repayIntent_(
+                8453,
+                cometUsdc_(8453),
+                "USDC",
+                type(uint256).max, // repaying max (all 10 USDC)
+                collateralAssetSymbols,
+                collateralAmounts
+            ),
+            chainAccountsFromChainPortfolios(chainPortfolios),
+            paymentUsdc_(maxCosts)
+        );
+
+        assertEq(result.paymentCurrency, "usdc", "usdc currency");
+
+        address cctpBridgeActionsAddress = CodeJarHelper.getCodeAddress(type(CCTPBridgeActions).creationCode);
+        address cometRepayAndWithdrawMultipleAssetsAddress =
+            CodeJarHelper.getCodeAddress(type(CometRepayAndWithdrawMultipleAssets).creationCode);
+        address paycallAddress = CodeJarHelper.getCodeAddress(
+            abi.encodePacked(type(Paycall).creationCode, abi.encode(ETH_USD_PRICE_FEED_1, USDC_1))
+        );
+        address paycallAddressBase = CodeJarHelper.getCodeAddress(
+            abi.encodePacked(type(Paycall).creationCode, abi.encode(ETH_USD_PRICE_FEED_8453, USDC_8453))
+        );
+
+        // Check the quark operations
+        // first operation
+        assertEq(result.quarkOperations.length, 2, "two operations");
+        assertEq(
+            result.quarkOperations[0].scriptAddress,
+            paycallAddress,
+            "script address is correct given the code jar address on base"
+        );
+        assertEq(
+            result.quarkOperations[0].scriptCalldata,
+            abi.encodeWithSelector(
+                Paycall.run.selector,
+                cctpBridgeActionsAddress,
+                abi.encodeWithSelector(
+                    CCTPBridgeActions.bridgeUSDC.selector,
+                    address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155),
+                    10.11e6, // 10e6 repaid + .1% buffer + 0.1e6 max cost on Base
+                    6,
+                    bytes32(uint256(uint160(0xa11ce))),
+                    usdc_(1)
+                ),
+                0.1e6
+            ),
+            "calldata is Paycall.run(CCTPBridgeActions.bridgeUSDC(0xBd3fa81B58Ba92a82136038B25aDec7066af3155, 10.11e6, 6, 0xa11ce, USDC_1)), 0.1e6);"
+        );
+        assertEq(result.quarkOperations[0].scriptSources.length, 2);
+        assertEq(result.quarkOperations[0].scriptSources[0], type(CCTPBridgeActions).creationCode);
+        assertEq(
+            result.quarkOperations[0].scriptSources[1],
+            abi.encodePacked(type(Paycall).creationCode, abi.encode(ETH_USD_PRICE_FEED_1, USDC_1))
+        );
+        assertEq(
+            result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
+        );
+
+        // second operation
+        assertEq(
+            result.quarkOperations[1].scriptAddress,
+            paycallAddressBase,
+            "script address[1] has been wrapped with paycall address"
+        );
+        assertEq(
+            result.quarkOperations[1].scriptCalldata,
+            abi.encodeWithSelector(
+                Paycall.run.selector,
+                cometRepayAndWithdrawMultipleAssetsAddress,
+                abi.encodeWithSelector(
+                    CometRepayAndWithdrawMultipleAssets.run.selector,
+                    cometUsdc_(8453),
+                    collateralTokens,
+                    collateralAmounts,
+                    usdc_(8453),
+                    type(uint256).max
+                ),
+                0.1e6
+            ),
+            "calldata is Paycall.run(CometRepayAndWithdrawMultipleAssets.run(cometUsdc_(8453), [], [], USDC_8453, uint256.max), 0.1e6);"
+        );
+        assertEq(result.quarkOperations[1].scriptSources.length, 2);
+        assertEq(result.quarkOperations[1].scriptSources[0], type(CometRepayAndWithdrawMultipleAssets).creationCode);
+        assertEq(
+            result.quarkOperations[1].scriptSources[1],
+            abi.encodePacked(type(Paycall).creationCode, abi.encode(ETH_USD_PRICE_FEED_8453, USDC_8453))
+        );
+        assertEq(
+            result.quarkOperations[1].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
+        );
+
+        // check the actions
+        // first action
+        assertEq(result.actions[0].chainId, 1, "operation is on chainid 1");
+        assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
+        assertEq(result.actions[0].actionType, "BRIDGE", "action type is 'BRIDGE'");
+        assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
+        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC on mainnet");
+        assertEq(result.actions[0].paymentMaxCost, 0.1e6, "payment should have max cost of 0.1e6");
+        assertEq(
+            result.actions[0].actionContext,
+            abi.encode(
+                Actions.BridgeActionContext({
+                    amount: 10.11e6,
+                    assetSymbol: "USDC",
+                    bridgeType: Actions.BRIDGE_TYPE_CCTP,
+                    chainId: 1,
+                    destinationChainId: 8453,
+                    price: USDC_PRICE,
+                    recipient: address(0xa11ce),
+                    token: USDC_1
+                })
+            ),
+            "action context encoded from BridgeActionContext"
+        );
+
+        // second action
+        assertEq(result.actions[1].chainId, 8453, "operation is on chainid 8453");
+        assertEq(result.actions[1].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
+        assertEq(result.actions[1].actionType, "REPAY", "action type is 'REPAY'");
+        assertEq(result.actions[1].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
+        assertEq(result.actions[1].paymentToken, USDC_8453, "payment token is USDC on Base");
+        assertEq(result.actions[1].paymentMaxCost, 0.1e6, "payment should have max cost of 0.1e6");
+
+        uint256[] memory collateralTokenPrices = new uint256[](0);
+
+        assertEq(
+            result.actions[1].actionContext,
+            abi.encode(
+                Actions.RepayActionContext({
+                    amount: type(uint256).max,
+                    assetSymbol: "USDC",
+                    chainId: 8453,
+                    collateralAmounts: collateralAmounts,
+                    collateralAssetSymbols: collateralAssetSymbols,
+                    collateralTokenPrices: collateralTokenPrices,
+                    collateralTokens: collateralTokens,
+                    comet: cometUsdc_(8453),
                     price: USDC_PRICE,
                     token: usdc_(8453)
                 })

--- a/test/builder/QuarkBuilderTransfer.t.sol
+++ b/test/builder/QuarkBuilderTransfer.t.sol
@@ -6,19 +6,19 @@ import "forge-std/console.sol";
 
 import {QuarkBuilderTest} from "test/builder/lib/QuarkBuilderTest.sol";
 
-import {TransferActions} from "src/DeFiScripts.sol";
 import {CCTPBridgeActions} from "src/BridgeScripts.sol";
 import {Multicall} from "src/Multicall.sol";
+import {TransferActions} from "src/DeFiScripts.sol";
 import {WrapperActions} from "src/WrapperScripts.sol";
 
 import {Actions} from "src/builder/Actions.sol";
 import {Accounts} from "src/builder/Accounts.sol";
 import {CodeJarHelper} from "src/builder/CodeJarHelper.sol";
-import {QuarkBuilder} from "src/builder/QuarkBuilder.sol";
 import {Paycall} from "src/Paycall.sol";
-import {Quotecall} from "src/Quotecall.sol";
 import {PaycallWrapper} from "src/builder/PaycallWrapper.sol";
 import {PaymentInfo} from "src/builder/PaymentInfo.sol";
+import {QuarkBuilder} from "src/builder/QuarkBuilder.sol";
+import {Quotecall} from "src/Quotecall.sol";
 
 contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
     function transferUsdc_(uint256 chainId, uint256 amount, address recipient, uint256 blockTimestamp)


### PR DESCRIPTION
This is a reworked version of #57 ; I've done it as a separate PR so we can compare the two approaches.

The downside of the approach in #57, as 🪄 correctly pointed out, is that the cost of wrapping/unwrapping assets would have to be incorporated into the `paymentTokenSpent` argument passed to `assertSufficientPaymentTokenBalances`. This would be logic that would have to be reimplemented by every function that used `assertSufficientPaymentTokenBalances`.

So instead, this PR maintains `assertSufficientPaymentTokenBalances` largely as it is, but adds an additional `account` argument. With `account`, `assertSufficientPaymentTokenBalances` can calculate the borrow amount for a max repay.
 
(This PR also incorporates the last pieces of feedback from #57: always using `Paycall` and adding a 0.1% buffer to the repay amount for max repays)
