### PR TITLE
Various QuarkBuilder fixes

### DIFF
--- a/src/builder/Actions.sol
+++ b/src/builder/Actions.sol
@@ -49,6 +49,7 @@ library Actions {
     uint256 constant SWAP_EXPIRY_BUFFER = 3 days;
     uint256 constant TRANSFER_EXPIRY_BUFFER = 7 days;
 
+    uint256 constant AVERAGE_BLOCK_TIME = 12 seconds;
     uint256 constant RECURRING_SWAP_MAX_SLIPPAGE = 1e17; // 1%
 
     /* ===== Custom Errors ===== */
@@ -1003,8 +1004,8 @@ library Actions {
         RecurringSwap.SwapParams memory swapParams = RecurringSwap.SwapParams({
             uniswapRouter: UniswapRouter.knownRouter(swap.chainId),
             recipient: swap.sender,
-            tokenIn: swap.buyToken,
-            tokenOut: swap.sellToken,
+            tokenIn: swap.sellToken,
+            tokenOut: swap.buyToken,
             amount: swap.isExactOut ? swap.buyAmount : swap.sellAmount,
             isExactOut: swap.isExactOut,
             // The swap never expires and needs to be cancelled explicity
@@ -1022,7 +1023,7 @@ library Actions {
             shouldInvert: shouldInvert
         });
         RecurringSwap.SwapConfig memory swapConfig = RecurringSwap.SwapConfig({
-            startTime: swap.blockTimestamp,
+            startTime: swap.blockTimestamp - AVERAGE_BLOCK_TIME,
             interval: swap.interval,
             swapParams: swapParams,
             slippageParams: slippageParams

--- a/src/builder/EIP712Helper.sol
+++ b/src/builder/EIP712Helper.sol
@@ -5,6 +5,7 @@ import {IQuarkWallet} from "quark-core/src/interfaces/IQuarkWallet.sol";
 import {QuarkWalletMetadata} from "quark-core/src/QuarkWallet.sol";
 
 import {Actions} from "./Actions.sol";
+import {Errors} from "./Errors.sol";
 
 library EIP712Helper {
     /* ===== Constants ===== */
@@ -41,10 +42,6 @@ library EIP712Helper {
             keccak256(bytes(QuarkWalletMetadata.VERSION))
         )
     );
-
-    /* ===== Custom Errors ===== */
-
-    error BadData();
 
     /* ===== Output Types ===== */
 
@@ -128,7 +125,7 @@ library EIP712Helper {
         Actions.Action[] memory actions
     ) internal pure returns (bytes32) {
         if (ops.length != actions.length) {
-            revert BadData();
+            revert Errors.BadData();
         }
 
         bytes32[] memory opDigests = new bytes32[](ops.length);

--- a/src/builder/Errors.sol
+++ b/src/builder/Errors.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity 0.8.23;
+
+/// Library of shared errors used across Quark Builder files
+library Errors {
+    error BadData();
+}

--- a/src/builder/PaymentInfo.sol
+++ b/src/builder/PaymentInfo.sol
@@ -32,7 +32,7 @@ library PaymentInfo {
     }
 
     function knownTokens() internal pure returns (PaymentToken[] memory) {
-        PaymentToken[] memory paymentTokens = new PaymentToken[](2);
+        PaymentToken[] memory paymentTokens = new PaymentToken[](3);
         paymentTokens[0] = PaymentToken({
             chainId: 1,
             symbol: "USDC",
@@ -48,6 +48,12 @@ library PaymentInfo {
             symbol: "USDC",
             token: 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913,
             priceFeed: 0x71041dddad3595F9CEd3DcCFBe3D1F4b0a16Bb70
+        });
+        paymentTokens[2] = PaymentToken({
+            chainId: 11155111,
+            symbol: "USDC",
+            token: 0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238,
+            priceFeed: 0x694AA1769357215DE4FAC081bf1f309aDC325306
         });
         return paymentTokens;
     }

--- a/src/builder/PaymentInfo.sol
+++ b/src/builder/PaymentInfo.sol
@@ -32,7 +32,7 @@ library PaymentInfo {
     }
 
     function knownTokens() internal pure returns (PaymentToken[] memory) {
-        PaymentToken[] memory paymentTokens = new PaymentToken[](3);
+        PaymentToken[] memory paymentTokens = new PaymentToken[](4);
         paymentTokens[0] = PaymentToken({
             chainId: 1,
             symbol: "USDC",
@@ -49,11 +49,19 @@ library PaymentInfo {
             token: 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913,
             priceFeed: 0x71041dddad3595F9CEd3DcCFBe3D1F4b0a16Bb70
         });
+
+        // Testnet
         paymentTokens[2] = PaymentToken({
             chainId: 11155111,
             symbol: "USDC",
             token: 0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238,
             priceFeed: 0x694AA1769357215DE4FAC081bf1f309aDC325306
+        });
+        paymentTokens[3] = PaymentToken({
+            chainId: 84532,
+            symbol: "USDC",
+            token: 0x036CbD53842c5426634e7929541eC2318f3dCF7e,
+            priceFeed: 0x4aDC67696bA383F43DD60A9e78F2C97Fbbfc7cb1
         });
         return paymentTokens;
     }

--- a/src/builder/QuarkOperationHelper.sol
+++ b/src/builder/QuarkOperationHelper.sol
@@ -7,6 +7,7 @@ import {Multicall} from "../Multicall.sol";
 
 import {Actions} from "./Actions.sol";
 import {CodeJarHelper} from "./CodeJarHelper.sol";
+import {Errors} from "./Errors.sol";
 import {PaycallWrapper} from "./PaycallWrapper.sol";
 import {PaymentInfo} from "./PaymentInfo.sol";
 import {QuotecallWrapper} from "./QuotecallWrapper.sol";
@@ -15,17 +16,13 @@ import {HashMap} from "./HashMap.sol";
 
 // Helper library to for transforming Quark Operations
 library QuarkOperationHelper {
-    /* ===== Custom Errors ===== */
-
-    error BadData();
-
     /* ===== Main Implementation ===== */
 
     function mergeSameChainOperations(
         IQuarkWallet.QuarkOperation[] memory quarkOperations,
         Actions.Action[] memory actions
     ) internal pure returns (IQuarkWallet.QuarkOperation[] memory, Actions.Action[] memory) {
-        if (quarkOperations.length != actions.length) revert BadData();
+        if (quarkOperations.length != actions.length) revert Errors.BadData();
 
         // Group operations and actions by chain id
         HashMap.Map memory groupedQuarkOperations = HashMap.newMap();

--- a/src/builder/UniswapRouter.sol
+++ b/src/builder/UniswapRouter.sol
@@ -10,16 +10,18 @@ library UniswapRouter {
     }
 
     /// @dev Addresses fetched from: https://docs.uniswap.org/contracts/v3/reference/deployments/
+    /// Note: We use the addresses for SwapRouter, instead of SwapRouter02, which has a slightly different interface
     function knownChains() internal pure returns (RouterChain[] memory) {
         RouterChain[] memory chains = new RouterChain[](4);
         // Mainnet
-        chains[0] = RouterChain({chainId: 1, router: 0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45});
+        chains[0] = RouterChain({chainId: 1, router: 0xE592427A0AEce92De3Edee1F18E0157C05861564});
+        // TODO: These chains don't have SwapRouter, so we will add them back once we move to SwapRouter02
         // Base
-        chains[1] = RouterChain({chainId: 8453, router: 0x2626664c2603336E57B271c5C0b26F421741e481});
+        // chains[1] = RouterChain({chainId: 8453, router: 0x2626664c2603336E57B271c5C0b26F421741e481});
         // Sepolia
-        chains[2] = RouterChain({chainId: 11155111, router: 0x3bFA4769FB09eefC5a80d6E87c3B9C650f7Ae48E});
+        // chains[2] = RouterChain({chainId: 11155111, router: 0x3bFA4769FB09eefC5a80d6E87c3B9C650f7Ae48E});
         // Base Sepolia
-        chains[3] = RouterChain({chainId: 84532, router: 0x94cC0AaC535CCDB3C01d6787D6413C739ae12bc4});
+        // chains[3] = RouterChain({chainId: 84532, router: 0x94cC0AaC535CCDB3C01d6787D6413C739ae12bc4});
         return chains;
     }
 

--- a/test/builder/QuarkBuilderRecurringSwap.t.sol
+++ b/test/builder/QuarkBuilderRecurringSwap.t.sol
@@ -82,8 +82,8 @@ contract QuarkBuilderRecurringSwapTest is Test, QuarkBuilderTest {
         RecurringSwap.SwapParams memory swapParams = RecurringSwap.SwapParams({
             uniswapRouter: UniswapRouter.knownRouter(swap.chainId),
             recipient: swap.sender,
-            tokenIn: swap.buyToken,
-            tokenOut: swap.sellToken,
+            tokenIn: swap.sellToken,
+            tokenOut: swap.buyToken,
             amount: swap.isExactOut ? swap.buyAmount : swap.sellAmount,
             isExactOut: swap.isExactOut,
             deadline: type(uint256).max,
@@ -97,7 +97,7 @@ contract QuarkBuilderRecurringSwapTest is Test, QuarkBuilderTest {
             shouldInvert: shouldInvert
         });
         return RecurringSwap.SwapConfig({
-            startTime: swap.blockTimestamp,
+            startTime: swap.blockTimestamp - Actions.AVERAGE_BLOCK_TIME,
             interval: swap.interval,
             swapParams: swapParams,
             slippageParams: slippageParams


### PR DESCRIPTION
Bundling a few different fixes in this PR:

- Give a bit more leniency to the `startTime` for recurring swaps by subtracting `AVERAGE_BLOCK_TIME` from the block timestamp
- Fix bug where buyToken and sellToken were in the wrong places when constructing recurring swap operations
- Move duplicated errors into an `Errors.sol` library 
- Add USDC on Sepolia as a payment token
- Use `SwapRouter` addresses instead of `SwapRouter02` addresses