### PR TITLE
Add isExactOut on one-time swaps

### DIFF
--- a/src/builder/Actions.sol
+++ b/src/builder/Actions.sol
@@ -477,7 +477,7 @@ library Actions {
             scriptAddress: CodeJarHelper.getCodeAddress(scriptSources[0]),
             scriptCalldata: CCTP.encodeBridgeUSDC(
                 bridge.srcChainId, bridge.destinationChainId, bridge.amount, bridge.recipient, srcUSDCPositions.asset
-            ),
+                ),
             scriptSources: scriptSources,
             expiry: bridge.blockTimestamp + BRIDGE_EXPIRY_BUFFER
         });
@@ -698,8 +698,7 @@ library Actions {
         bytes memory scriptCalldata;
         if (Strings.stringEqIgnoreCase(cometSupply.assetSymbol, "ETH")) {
             // XXX handle wrapping ETH
-        }
-        else {
+        } else {
             scriptCalldata = abi.encodeWithSelector(
                 CometSupplyActions.supply.selector, cometSupply.comet, assetPositions.asset, cometSupply.amount
             );
@@ -757,8 +756,7 @@ library Actions {
         bytes memory scriptCalldata;
         if (Strings.stringEqIgnoreCase(cometWithdraw.assetSymbol, "ETH")) {
             // XXX handle unwrapping ETH
-        }
-        else {
+        } else {
             scriptCalldata = abi.encodeWithSelector(
                 CometWithdrawActions.withdraw.selector, cometWithdraw.comet, assetPositions.asset, cometWithdraw.amount
             );
@@ -881,7 +879,7 @@ library Actions {
             scriptAddress: CodeJarHelper.getCodeAddress(type(WrapperActions).creationCode),
             scriptCalldata: TokenWrapper.encodeActionToWrapOrUnwrap(
                 wrapOrUnwrap.chainId, wrapOrUnwrap.assetSymbol, wrapOrUnwrap.amount
-            ),
+                ),
             scriptSources: scriptSources,
             expiry: wrapOrUnwrap.blockTimestamp + STANDARD_EXPIRY_BUFFER
         });

--- a/src/builder/Actions.sol
+++ b/src/builder/Actions.sol
@@ -116,6 +116,7 @@ library Actions {
         uint256 feeAmount;
         uint256 chainId;
         address sender;
+        bool isExactOut;
         uint256 blockTimestamp;
     }
 
@@ -246,6 +247,7 @@ library Actions {
         string outputAssetSymbol;
         address outputToken;
         uint256 outputTokenPrice;
+        bool isExactOut;
     }
 
     struct RecurringSwapActionContext {
@@ -475,7 +477,7 @@ library Actions {
             scriptAddress: CodeJarHelper.getCodeAddress(scriptSources[0]),
             scriptCalldata: CCTP.encodeBridgeUSDC(
                 bridge.srcChainId, bridge.destinationChainId, bridge.amount, bridge.recipient, srcUSDCPositions.asset
-                ),
+            ),
             scriptSources: scriptSources,
             expiry: bridge.blockTimestamp + BRIDGE_EXPIRY_BUFFER
         });
@@ -696,7 +698,8 @@ library Actions {
         bytes memory scriptCalldata;
         if (Strings.stringEqIgnoreCase(cometSupply.assetSymbol, "ETH")) {
             // XXX handle wrapping ETH
-        } else {
+        }
+        else {
             scriptCalldata = abi.encodeWithSelector(
                 CometSupplyActions.supply.selector, cometSupply.comet, assetPositions.asset, cometSupply.amount
             );
@@ -754,7 +757,8 @@ library Actions {
         bytes memory scriptCalldata;
         if (Strings.stringEqIgnoreCase(cometWithdraw.assetSymbol, "ETH")) {
             // XXX handle unwrapping ETH
-        } else {
+        }
+        else {
             scriptCalldata = abi.encodeWithSelector(
                 CometWithdrawActions.withdraw.selector, cometWithdraw.comet, assetPositions.asset, cometWithdraw.amount
             );
@@ -877,7 +881,7 @@ library Actions {
             scriptAddress: CodeJarHelper.getCodeAddress(type(WrapperActions).creationCode),
             scriptCalldata: TokenWrapper.encodeActionToWrapOrUnwrap(
                 wrapOrUnwrap.chainId, wrapOrUnwrap.assetSymbol, wrapOrUnwrap.amount
-                ),
+            ),
             scriptSources: scriptSources,
             expiry: wrapOrUnwrap.blockTimestamp + STANDARD_EXPIRY_BUFFER
         });
@@ -965,7 +969,8 @@ library Actions {
             outputAmount: swap.buyAmount,
             outputAssetSymbol: swap.buyAssetSymbol,
             outputToken: swap.buyToken,
-            outputTokenPrice: buyTokenAssetPositions.usdPrice
+            outputTokenPrice: buyTokenAssetPositions.usdPrice,
+            isExactOut: swap.isExactOut
         });
 
         Action memory action = Actions.Action({

--- a/src/builder/QuarkBuilder.sol
+++ b/src/builder/QuarkBuilder.sol
@@ -826,6 +826,7 @@ contract QuarkBuilder {
         address feeToken;
         uint256 feeAmount;
         address sender;
+        bool isExactOut;
         uint256 blockTimestamp;
     }
 
@@ -947,6 +948,7 @@ contract QuarkBuilder {
                 feeAmount: swapIntent.feeAmount,
                 chainId: swapIntent.chainId,
                 sender: swapIntent.sender,
+                isExactOut: swapIntent.isExactOut,
                 blockTimestamp: swapIntent.blockTimestamp
             }),
             payment,

--- a/test/builder/QuarkBuilderSwap.t.sol
+++ b/test/builder/QuarkBuilderSwap.t.sol
@@ -90,6 +90,7 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
             feeToken: buyToken,
             feeAmount: 10,
             sender: sender,
+            isExactOut: false,
             blockTimestamp: blockTimestamp
         });
     }
@@ -205,7 +206,8 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
                     outputToken: WETH_1,
                     outputTokenPrice: WETH_PRICE,
                     outputAssetSymbol: "WETH",
-                    outputAmount: 1e18
+                    outputAmount: 1e18,
+                    isExactOut: false
                 })
             ),
             "action context encoded from SwapActionContext"
@@ -309,7 +311,8 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
                     outputToken: USDC_1,
                     outputTokenPrice: USDC_PRICE,
                     outputAssetSymbol: "USDC",
-                    outputAmount: 3000e6
+                    outputAmount: 3000e6,
+                    isExactOut: false
                 })
             ),
             "action context encoded from SwapActionContext"
@@ -384,7 +387,8 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
                     outputToken: WETH_1,
                     outputTokenPrice: WETH_PRICE,
                     outputAssetSymbol: "WETH",
-                    outputAmount: 1e18
+                    outputAmount: 1e18,
+                    isExactOut: false
                 })
             ),
             "action context encoded from SwapActionContext"
@@ -479,7 +483,8 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
                     outputToken: WETH_1,
                     outputTokenPrice: WETH_PRICE,
                     outputAssetSymbol: "WETH",
-                    outputAmount: 3e18
+                    outputAmount: 3e18,
+                    isExactOut: false
                 })
             ),
             "action context encoded from SwapActionContext"
@@ -617,7 +622,8 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
                     outputToken: WETH_8453,
                     outputTokenPrice: WETH_PRICE,
                     outputAssetSymbol: "WETH",
-                    outputAmount: 1e18
+                    outputAmount: 1e18,
+                    isExactOut: false
                 })
             ),
             "action context encoded from SwapActionContext"
@@ -752,7 +758,8 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
                     outputToken: WETH_8453,
                     outputTokenPrice: WETH_PRICE,
                     outputAssetSymbol: "WETH",
-                    outputAmount: 1e18
+                    outputAmount: 1e18,
+                    isExactOut: false
                 })
             ),
             "action context encoded from SwapActionContext"
@@ -886,7 +893,8 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
                     outputToken: WETH_8453,
                     outputTokenPrice: WETH_PRICE,
                     outputAssetSymbol: "WETH",
-                    outputAmount: 2e18
+                    outputAmount: 2e18,
+                    isExactOut: false
                 })
             ),
             "action context encoded from SwapActionContext"
@@ -1021,7 +1029,8 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
                     outputToken: WETH_8453,
                     outputTokenPrice: WETH_PRICE,
                     outputAssetSymbol: "WETH",
-                    outputAmount: 1e18
+                    outputAmount: 1e18,
+                    isExactOut: false
                 })
             ),
             "action context encoded from SwapActionContext"


### PR DESCRIPTION
The one-time swap intent is used to generate the recurring intent, so we need to add `isExactOut` to the one-time swap so it can be propagated over