### PR TITLE
Add paycall address test

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -5,15 +5,14 @@ test = "test"
 solc = "0.8.23"
 evm_version = "paris"
 
-libs = [ "./lib" ]
+libs = ["./lib"]
 
 [profile.ir]
 via_ir = true
 optimizer = true
 optimizer_runs = 100000000
+bytecode_hash = "none"
+cbor_metadata = false
 
 [fmt]
 ignore = ["src/vendor/**/*"]
-
-bytecode_hash = "none"
-cbor_metadata = false

--- a/foundry.toml
+++ b/foundry.toml
@@ -4,6 +4,8 @@ out = "out"
 test = "test"
 solc = "0.8.23"
 evm_version = "paris"
+bytecode_hash = "none"
+cbor_metadata = false
 
 libs = ["./lib"]
 
@@ -11,8 +13,6 @@ libs = ["./lib"]
 via_ir = true
 optimizer = true
 optimizer_runs = 100000000
-bytecode_hash = "none"
-cbor_metadata = false
 
 [fmt]
 ignore = ["src/vendor/**/*"]

--- a/test/Paycall.t.sol
+++ b/test/Paycall.t.sol
@@ -452,10 +452,9 @@ contract PaycallTest is Test {
     function testPaycallAddress() public {
         // If this test fails, the paycall code has been updated which means the
         // backend must be updated accordingly
+
         vm.createSelectFork(
-            string.concat(
-                "https://node-provider.compound.finance/ethereum-mainnet/", vm.envString("NODE_PROVIDER_BYPASS_KEY")
-            ),
+            vm.envString("MAINNET_RPC_URL"),
             20764080 // 2024-09-16 08:31:00 PST
         );
 

--- a/test/Paycall.t.sol
+++ b/test/Paycall.t.sol
@@ -22,6 +22,7 @@ import {Reverts} from "./lib/Reverts.sol";
 import {YulHelper} from "./lib/YulHelper.sol";
 import {SignatureHelper} from "./lib/SignatureHelper.sol";
 import {QuarkOperationHelper, ScriptType} from "./lib/QuarkOperationHelper.sol";
+import {CodeJarHelper} from "src/builder/CodeJarHelper.sol";
 import "src/vendor/chainlink/AggregatorV3Interface.sol";
 
 import "src/DeFiScripts.sol";
@@ -446,5 +447,19 @@ contract PaycallTest is Test {
         wallet.executeQuarkOperation(op, v, r, s);
 
         assertEq(IERC20(USDC).balanceOf(address(wallet)), 1000e6);
+    }
+
+    function testPaycallAddress() public {
+        // If this test fails, the paycall code has been updated which means the
+        // backend must be updated accordingly
+        vm.createSelectFork(
+            string.concat(
+                "https://node-provider.compound.finance/ethereum-mainnet/", vm.envString("NODE_PROVIDER_BYPASS_KEY")
+            ),
+            20764080 // 2024-09-16 08:31:00 PST
+        );
+
+        CodeJar mainnetCodejar = CodeJar(CodeJarHelper.CODE_JAR_ADDRESS);
+        assertEq(mainnetCodejar.getCodeAddress(paycall), 0x1aF2e314e3291c6a4cD52A210a1AF027c7799cce);
     }
 }

--- a/test/Paycall.t.sol
+++ b/test/Paycall.t.sol
@@ -450,8 +450,8 @@ contract PaycallTest is Test {
     }
 
     function testPaycallAddress() public {
-        // If this test fails, the paycall code has been updated which means the
-        // backend must be updated accordingly
+        // If this test fails, the paycall code has been updated, which means any
+        // validation done with the bytecode must be updated.
 
         vm.createSelectFork(
             vm.envString("MAINNET_RPC_URL"),


### PR DESCRIPTION
It's cumbersome when a change to quark scripts leads to a mismatched paycall address when performing server side validation since server code is tightly coupled to the quark script bytecode. This adds a test to make sure sirens go off when the paycall address changes due to a change in bytecode.

In this case, the paycall address was changed due to a change in `foundry.toml` where the `bytecode_hash` and `cbor_metadata` were in a different toml table than before. I've also updated the `foundry.toml` to fix this here