### PR TITLE
Add EIP-712 Change for Quark V2

### DIFF
--- a/src/builder/EIP712Helper.sol
+++ b/src/builder/EIP712Helper.sol
@@ -90,6 +90,7 @@ library EIP712Helper {
             abi.encode(
                 QUARK_OPERATION_TYPEHASH,
                 op.nonce,
+                op.isReplayable,
                 op.scriptAddress,
                 keccak256(encodedScriptSources),
                 keccak256(op.scriptCalldata),


### PR DESCRIPTION
This patch adds an EIP-712 change for Quark V2, which adds an `isReplayable` field in the typehash of the EIP-712 struct.