### PR TITLE
Use FFI to perform paycall multi-step simulation

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -6,12 +6,14 @@ solc = "0.8.27"
 evm_version = "cancun"
 bytecode_hash = "none"
 cbor_metadata = false
+# Ignore the tstore warning
+ignored_error_codes = [2394]
 
 libs = ["./lib"]
 
 [profile.ir]
 via_ir = true
-optimizer = true
+optimizer = false
 optimizer_runs = 100000000
 
 [fmt]

--- a/src/builder/QuarkBuilderBase.sol
+++ b/src/builder/QuarkBuilderBase.sol
@@ -95,6 +95,9 @@ contract QuarkBuilderBase {
     )
         internal
         view
+        // TODO: Perhaps this should also return the simulation so we don't have to do that again from the client side. 
+        // However, we will need to resimulate on the client on an interval anyway, so I'm not sure. Perhaps we expose another function
+        // that just takes quark operations array, actions array and payment that does the resimulation
         returns (IQuarkWallet.QuarkOperation[] memory quarkOperationsArray, Actions.Action[] memory actionsArray)
     {
         if (!payment.isToken) {

--- a/src/builder/SimulationHelper.sol
+++ b/src/builder/SimulationHelper.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity ^0.8.27;
+
+import {QuarkBuilderBase} from "src/builder/QuarkBuilderBase.sol";
+
+library SimulationHelper {
+    // Estimate from CCTP bridge action (including paycall): 0x894f0e4c944db179d0f573aab2c349d7f6df07690ac3772cf744e73a9208a79d
+    uint256 constant BRIDGE_GAS_AMOUNT = 430_000;
+
+    function getMaxCost(
+        uint256 chainId,
+        QuarkBuilderBase.GasPricesResult memory gasPrices,
+        uint256 estimatedGas
+    ) internal pure returns (uint256) {
+        QuarkBuilderBase.GasPrice memory gasPrice = getGasPrice(
+            chainId,
+            gasPrices
+        );
+
+        return
+            (estimatedGas * gasPrice.ethGasPrice * gasPrices.currencyPrice) /
+            1e18;
+    }
+
+    function getGasPrice(
+        uint256 chainId,
+        QuarkBuilderBase.GasPricesResult memory gasPrices
+    ) internal pure returns (QuarkBuilderBase.GasPrice memory) {
+        QuarkBuilderBase.GasPrice memory gasPrice;
+
+        for (uint256 i = 0; i < gasPrices.gasPrices.length; i++) {
+            if (gasPrices.gasPrices[i].chainId == chainId) {
+                gasPrice = gasPrices.gasPrices[i];
+                break;
+            }
+        }
+
+        return gasPrice;
+    }
+}

--- a/src/builder/actions/Actions.sol
+++ b/src/builder/actions/Actions.sol
@@ -68,6 +68,9 @@ library Actions {
     uint256 constant RECURRING_SWAP_MAX_SLIPPAGE = 1e17; // 1%
     uint256 constant RECURRING_SWAP_WINDOW_LENGTH = 1 days;
 
+    /* FFI Addresses (starts from 0xFF1000, FFI with 100 reserved addresses) */
+    address constant SIMULATE_FFI_ADDRESS = address(0xFF1001);
+
     /* ===== Custom Errors ===== */
 
     error BridgingUnsupportedForAsset();

--- a/src/builder/actions/Actions.sol
+++ b/src/builder/actions/Actions.sol
@@ -69,7 +69,7 @@ library Actions {
     uint256 constant RECURRING_SWAP_WINDOW_LENGTH = 1 days;
 
     /* FFI Addresses (starts from 0xFF1000, FFI with 100 reserved addresses) */
-    address constant SIMULATE_FFI_ADDRESS = address(0xFF1001);
+    address constant SIMULATION_FFI_ADDRESS = address(0xFF1001);
 
     /* ===== Custom Errors ===== */
 

--- a/src/builder/actions/Actions.sol
+++ b/src/builder/actions/Actions.sol
@@ -70,6 +70,7 @@ library Actions {
 
     /* FFI Addresses (starts from 0xFF1000, FFI with 100 reserved addresses) */
     address constant SIMULATION_FFI_ADDRESS = address(0xFF1001);
+    address constant GAS_PRICE_FFI_ADDRESS = address(0xFF1002);
 
     /* ===== Custom Errors ===== */
 

--- a/src/builder/actions/Actions.sol
+++ b/src/builder/actions/Actions.sol
@@ -975,6 +975,7 @@ library Actions {
         Accounts.QuarkSecret memory accountSecret = Accounts.findQuarkSecret(transfer.sender, accounts.quarkSecrets);
 
         bytes memory scriptCalldata;
+        // TODO: The client always sends WETH, so i think this branch is never called
         if (Strings.stringEqIgnoreCase(transfer.assetSymbol, "ETH")) {
             // Native token transfer
             scriptCalldata = abi.encodeWithSelector(

--- a/src/builder/actions/CometActionsBuilder.sol
+++ b/src/builder/actions/CometActionsBuilder.sol
@@ -88,18 +88,21 @@ contract CometActionsBuilder is QuarkBuilderBase {
         }
 
         (IQuarkWallet.QuarkOperation[] memory quarkOperationsArray, Actions.Action[] memory actionsArray) =
-        QuarkBuilderBase.collectAssetsForAction({
-            actionIntent: actionIntent,
-            chainAccountsList: chainAccountsList,
-            payment: payment,
-            actionQuarkOperation: repayQuarkOperation,
-            action: repayAction
-        });
+            (new IQuarkWallet.QuarkOperation[](0), new Actions.Action[](0));
+        // (IQuarkWallet.QuarkOperation[] memory quarkOperationsArray, Actions.Action[] memory actionsArray) =
+        // QuarkBuilderBase.collectAssetsForAction({
+        //     actionIntent: actionIntent,
+        //     chainAccountsList: chainAccountsList,
+        //     payment: payment,
+        //     actionQuarkOperation: repayQuarkOperation,
+        //     action: repayAction
+        // });
 
         return BuilderResult({
             version: VERSION,
             actions: actionsArray,
             quarkOperations: quarkOperationsArray,
+            simulations: new Simulation[](0),
             paymentCurrency: payment.currency,
             eip712Data: EIP712Helper.eip712DataForQuarkOperations(quarkOperationsArray, actionsArray)
         });
@@ -165,18 +168,21 @@ contract CometActionsBuilder is QuarkBuilderBase {
         }
 
         (IQuarkWallet.QuarkOperation[] memory quarkOperationsArray, Actions.Action[] memory actionsArray) =
-        QuarkBuilderBase.collectAssetsForAction({
-            actionIntent: actionIntent,
-            chainAccountsList: chainAccountsList,
-            payment: payment,
-            actionQuarkOperation: borrowQuarkOperation,
-            action: borrowAction
-        });
+            (new IQuarkWallet.QuarkOperation[](0), new Actions.Action[](0));
+        // (IQuarkWallet.QuarkOperation[] memory quarkOperationsArray, Actions.Action[] memory actionsArray) =
+        // QuarkBuilderBase.collectAssetsForAction({
+        //     actionIntent: actionIntent,
+        //     chainAccountsList: chainAccountsList,
+        //     payment: payment,
+        //     actionQuarkOperation: borrowQuarkOperation,
+        //     action: borrowAction
+        // });
 
         return BuilderResult({
             version: VERSION,
             actions: actionsArray,
             quarkOperations: quarkOperationsArray,
+            simulations: new Simulation[](0),
             paymentCurrency: payment.currency,
             eip712Data: EIP712Helper.eip712DataForQuarkOperations(quarkOperationsArray, actionsArray)
         });
@@ -234,30 +240,33 @@ contract CometActionsBuilder is QuarkBuilderBase {
             uint256[] memory amountIns = new uint256[](0);
             string[] memory assetSymbolIns = new string[](0);
 
-            (quarkOperationsArray, actionsArray) = QuarkBuilderBase.collectAssetsForAction({
-                actionIntent: QuarkBuilderBase.ActionIntent({
-                    actor: cometSupplyIntent.sender,
-                    amountIns: amountIns,
-                    assetSymbolIns: assetSymbolIns,
-                    amountOuts: amountOuts,
-                    assetSymbolOuts: assetSymbolOuts,
-                    blockTimestamp: cometSupplyIntent.blockTimestamp,
-                    chainId: cometSupplyIntent.chainId,
-                    useQuotecall: isMaxSupply,
-                    bridgeEnabled: true,
-                    autoWrapperEnabled: true
-                }),
-                chainAccountsList: chainAccountsList,
-                payment: payment,
-                actionQuarkOperation: supplyQuarkOperation,
-                action: supplyAction
-            });
+            (IQuarkWallet.QuarkOperation[] memory quarkOperationsArray, Actions.Action[] memory actionsArray) =
+                (new IQuarkWallet.QuarkOperation[](0), new Actions.Action[](0));
+            // (quarkOperationsArray, actionsArray) = QuarkBuilderBase.collectAssetsForAction({
+            //     actionIntent: QuarkBuilderBase.ActionIntent({
+            //         actor: cometSupplyIntent.sender,
+            //         amountIns: amountIns,
+            //         assetSymbolIns: assetSymbolIns,
+            //         amountOuts: amountOuts,
+            //         assetSymbolOuts: assetSymbolOuts,
+            //         blockTimestamp: cometSupplyIntent.blockTimestamp,
+            //         chainId: cometSupplyIntent.chainId,
+            //         useQuotecall: isMaxSupply,
+            //         bridgeEnabled: true,
+            //         autoWrapperEnabled: true
+            //     }),
+            //     chainAccountsList: chainAccountsList,
+            //     payment: payment,
+            //     actionQuarkOperation: supplyQuarkOperation,
+            //     action: supplyAction
+            // });
         }
 
         return BuilderResult({
             version: VERSION,
             actions: actionsArray,
             quarkOperations: quarkOperationsArray,
+            simulations: new Simulation[](0),
             paymentCurrency: payment.currency,
             eip712Data: EIP712Helper.eip712DataForQuarkOperations(quarkOperationsArray, actionsArray)
         });
@@ -319,30 +328,33 @@ contract CometActionsBuilder is QuarkBuilderBase {
             uint256[] memory amountOuts = new uint256[](0);
             string[] memory assetSymbolOuts = new string[](0);
 
-            (quarkOperationsArray, actionsArray) = QuarkBuilderBase.collectAssetsForAction({
-                actionIntent: QuarkBuilderBase.ActionIntent({
-                    actor: cometWithdrawIntent.withdrawer,
-                    amountIns: amountIns,
-                    assetSymbolIns: assetSymbolIns,
-                    amountOuts: amountOuts,
-                    assetSymbolOuts: assetSymbolOuts,
-                    blockTimestamp: cometWithdrawIntent.blockTimestamp,
-                    chainId: cometWithdrawIntent.chainId,
-                    useQuotecall: useQuotecall,
-                    bridgeEnabled: true,
-                    autoWrapperEnabled: true
-                }),
-                chainAccountsList: chainAccountsList,
-                payment: payment,
-                actionQuarkOperation: cometWithdrawQuarkOperation,
-                action: cometWithdrawAction
-            });
+            (IQuarkWallet.QuarkOperation[] memory quarkOperationsArray, Actions.Action[] memory actionsArray) =
+                (new IQuarkWallet.QuarkOperation[](0), new Actions.Action[](0));
+            // (quarkOperationsArray, actionsArray) = QuarkBuilderBase.collectAssetsForAction({
+            //     actionIntent: QuarkBuilderBase.ActionIntent({
+            //         actor: cometWithdrawIntent.withdrawer,
+            //         amountIns: amountIns,
+            //         assetSymbolIns: assetSymbolIns,
+            //         amountOuts: amountOuts,
+            //         assetSymbolOuts: assetSymbolOuts,
+            //         blockTimestamp: cometWithdrawIntent.blockTimestamp,
+            //         chainId: cometWithdrawIntent.chainId,
+            //         useQuotecall: useQuotecall,
+            //         bridgeEnabled: true,
+            //         autoWrapperEnabled: true
+            //     }),
+            //     chainAccountsList: chainAccountsList,
+            //     payment: payment,
+            //     actionQuarkOperation: cometWithdrawQuarkOperation,
+            //     action: cometWithdrawAction
+            // });
         }
 
         return BuilderResult({
             version: VERSION,
             actions: actionsArray,
             quarkOperations: quarkOperationsArray,
+            simulations: new Simulation[](0),
             paymentCurrency: payment.currency,
             eip712Data: EIP712Helper.eip712DataForQuarkOperations(quarkOperationsArray, actionsArray)
         });

--- a/src/builder/actions/MorphoActionsBuilder.sol
+++ b/src/builder/actions/MorphoActionsBuilder.sol
@@ -76,18 +76,21 @@ contract MorphoActionsBuilder is QuarkBuilderBase {
         }
 
         (IQuarkWallet.QuarkOperation[] memory quarkOperationsArray, Actions.Action[] memory actionsArray) =
-        QuarkBuilderBase.collectAssetsForAction({
-            actionIntent: actionIntent,
-            chainAccountsList: chainAccountsList,
-            payment: payment,
-            actionQuarkOperation: borrowQuarkOperation,
-            action: borrowAction
-        });
+            (new IQuarkWallet.QuarkOperation[](0), new Actions.Action[](0));
+        // (IQuarkWallet.QuarkOperation[] memory quarkOperationsArray, Actions.Action[] memory actionsArray) =
+        // QuarkBuilderBase.collectAssetsForAction({
+        //     actionIntent: actionIntent,
+        //     chainAccountsList: chainAccountsList,
+        //     payment: payment,
+        //     actionQuarkOperation: borrowQuarkOperation,
+        //     action: borrowAction
+        // });
 
         return BuilderResult({
             version: VERSION,
             actions: actionsArray,
             quarkOperations: quarkOperationsArray,
+            simulations: new Simulation[](0),
             paymentCurrency: payment.currency,
             eip712Data: EIP712Helper.eip712DataForQuarkOperations(quarkOperationsArray, actionsArray)
         });
@@ -152,30 +155,33 @@ contract MorphoActionsBuilder is QuarkBuilderBase {
             string[] memory assetSymbolIns = new string[](1);
             assetSymbolIns[0] = repayIntent.collateralAssetSymbol;
 
-            (quarkOperationsArray, actionsArray) = QuarkBuilderBase.collectAssetsForAction({
-                actionIntent: QuarkBuilderBase.ActionIntent({
-                    actor: repayIntent.repayer,
-                    amountIns: amountIns,
-                    assetSymbolIns: assetSymbolIns,
-                    amountOuts: amountOuts,
-                    assetSymbolOuts: assetSymbolOuts,
-                    blockTimestamp: repayIntent.blockTimestamp,
-                    chainId: repayIntent.chainId,
-                    useQuotecall: useQuotecall,
-                    bridgeEnabled: true,
-                    autoWrapperEnabled: true
-                }),
-                chainAccountsList: chainAccountsList,
-                payment: payment,
-                actionQuarkOperation: repayQuarkOperations,
-                action: repayActions
-            });
+            (IQuarkWallet.QuarkOperation[] memory quarkOperationsArray, Actions.Action[] memory actionsArray) =
+                (new IQuarkWallet.QuarkOperation[](0), new Actions.Action[](0));
+            // (quarkOperationsArray, actionsArray) = QuarkBuilderBase.collectAssetsForAction({
+            //     actionIntent: QuarkBuilderBase.ActionIntent({
+            //         actor: repayIntent.repayer,
+            //         amountIns: amountIns,
+            //         assetSymbolIns: assetSymbolIns,
+            //         amountOuts: amountOuts,
+            //         assetSymbolOuts: assetSymbolOuts,
+            //         blockTimestamp: repayIntent.blockTimestamp,
+            //         chainId: repayIntent.chainId,
+            //         useQuotecall: useQuotecall,
+            //         bridgeEnabled: true,
+            //         autoWrapperEnabled: true
+            //     }),
+            //     chainAccountsList: chainAccountsList,
+            //     payment: payment,
+            //     actionQuarkOperation: repayQuarkOperations,
+            //     action: repayActions
+            // });
         }
 
         return BuilderResult({
             version: VERSION,
             actions: actionsArray,
             quarkOperations: quarkOperationsArray,
+            simulations: new Simulation[](0),
             paymentCurrency: payment.currency,
             eip712Data: EIP712Helper.eip712DataForQuarkOperations(quarkOperationsArray, actionsArray)
         });
@@ -251,18 +257,21 @@ contract MorphoActionsBuilder is QuarkBuilderBase {
         }
 
         (IQuarkWallet.QuarkOperation[] memory quarkOperationsArray, Actions.Action[] memory actionsArray) =
-        collectAssetsForAction({
-            actionIntent: actionIntent,
-            chainAccountsList: chainAccountsList,
-            payment: payment,
-            actionQuarkOperation: morphoClaimRewardsQuarkOperation,
-            action: morphoClaimRewardsAction
-        });
+            (new IQuarkWallet.QuarkOperation[](0), new Actions.Action[](0));
+        // (IQuarkWallet.QuarkOperation[] memory quarkOperationsArray, Actions.Action[] memory actionsArray) =
+        // collectAssetsForAction({
+        //     actionIntent: actionIntent,
+        //     chainAccountsList: chainAccountsList,
+        //     payment: payment,
+        //     actionQuarkOperation: morphoClaimRewardsQuarkOperation,
+        //     action: morphoClaimRewardsAction
+        // });
 
         return BuilderResult({
             version: VERSION,
             actions: actionsArray,
             quarkOperations: quarkOperationsArray,
+            simulations: new Simulation[](0),
             paymentCurrency: payment.currency,
             eip712Data: EIP712Helper.eip712DataForQuarkOperations(quarkOperationsArray, actionsArray)
         });

--- a/src/builder/actions/MorphoVaultActionsBuilder.sol
+++ b/src/builder/actions/MorphoVaultActionsBuilder.sol
@@ -69,30 +69,33 @@ contract MorphoVaultActionsBuilder is QuarkBuilderBase {
             uint256[] memory amountIns = new uint256[](0);
             string[] memory assetSymbolIns = new string[](0);
 
-            (quarkOperationsArray, actionsArray) = collectAssetsForAction({
-                actionIntent: ActionIntent({
-                    actor: supplyIntent.sender,
-                    amountIns: amountIns,
-                    assetSymbolIns: assetSymbolIns,
-                    amountOuts: amountOuts,
-                    assetSymbolOuts: assetSymbolOuts,
-                    blockTimestamp: supplyIntent.blockTimestamp,
-                    chainId: supplyIntent.chainId,
-                    useQuotecall: useQuotecall,
-                    bridgeEnabled: true,
-                    autoWrapperEnabled: true
-                }),
-                chainAccountsList: chainAccountsList,
-                payment: payment,
-                actionQuarkOperation: supplyQuarkOperation,
-                action: supplyAction
-            });
+            (IQuarkWallet.QuarkOperation[] memory quarkOperationsArray, Actions.Action[] memory actionsArray) =
+                (new IQuarkWallet.QuarkOperation[](0), new Actions.Action[](0));
+            // (quarkOperationsArray, actionsArray) = collectAssetsForAction({
+            //     actionIntent: ActionIntent({
+            //         actor: supplyIntent.sender,
+            //         amountIns: amountIns,
+            //         assetSymbolIns: assetSymbolIns,
+            //         amountOuts: amountOuts,
+            //         assetSymbolOuts: assetSymbolOuts,
+            //         blockTimestamp: supplyIntent.blockTimestamp,
+            //         chainId: supplyIntent.chainId,
+            //         useQuotecall: useQuotecall,
+            //         bridgeEnabled: true,
+            //         autoWrapperEnabled: true
+            //     }),
+            //     chainAccountsList: chainAccountsList,
+            //     payment: payment,
+            //     actionQuarkOperation: supplyQuarkOperation,
+            //     action: supplyAction
+            // });
         }
 
         return BuilderResult({
             version: VERSION,
             actions: actionsArray,
             quarkOperations: quarkOperationsArray,
+            simulations: new Simulation[](0),
             paymentCurrency: payment.currency,
             eip712Data: EIP712Helper.eip712DataForQuarkOperations(quarkOperationsArray, actionsArray)
         });
@@ -171,18 +174,21 @@ contract MorphoVaultActionsBuilder is QuarkBuilderBase {
         }
 
         (IQuarkWallet.QuarkOperation[] memory quarkOperationsArray, Actions.Action[] memory actionsArray) =
-        collectAssetsForAction({
-            actionIntent: actionIntent,
-            chainAccountsList: chainAccountsList,
-            payment: payment,
-            actionQuarkOperation: cometWithdrawQuarkOperation,
-            action: cometWithdrawAction
-        });
+            (new IQuarkWallet.QuarkOperation[](0), new Actions.Action[](0));
+        // (IQuarkWallet.QuarkOperation[] memory quarkOperationsArray, Actions.Action[] memory actionsArray) =
+        // collectAssetsForAction({
+        //     actionIntent: actionIntent,
+        //     chainAccountsList: chainAccountsList,
+        //     payment: payment,
+        //     actionQuarkOperation: cometWithdrawQuarkOperation,
+        //     action: cometWithdrawAction
+        // });
 
         return BuilderResult({
             version: VERSION,
             actions: actionsArray,
             quarkOperations: quarkOperationsArray,
+            simulations: new Simulation[](0),
             paymentCurrency: payment.currency,
             eip712Data: EIP712Helper.eip712DataForQuarkOperations(quarkOperationsArray, actionsArray)
         });

--- a/src/builder/actions/SwapActionsBuilder.sol
+++ b/src/builder/actions/SwapActionsBuilder.sol
@@ -115,19 +115,22 @@ contract SwapActionsBuilder is QuarkBuilderBase {
                 });
             }
 
-            (quarkOperationsArray, actionsArray) = collectAssetsForAction({
-                actionIntent: actionIntent,
-                chainAccountsList: chainAccountsList,
-                payment: payment,
-                actionQuarkOperation: operation,
-                action: action
-            });
+            (IQuarkWallet.QuarkOperation[] memory quarkOperationsArray, Actions.Action[] memory actionsArray) =
+            (new IQuarkWallet.QuarkOperation[](0), new Actions.Action[](0));
+            // (quarkOperationsArray, actionsArray) = collectAssetsForAction({
+            //     actionIntent: actionIntent,
+            //     chainAccountsList: chainAccountsList,
+            //     payment: payment,
+            //     actionQuarkOperation: operation,
+            //     action: action
+            // });
         }
 
         return BuilderResult({
             version: VERSION,
             actions: actionsArray,
             quarkOperations: quarkOperationsArray,
+            simulations: new Simulation[](0),
             paymentCurrency: payment.currency,
             eip712Data: EIP712Helper.eip712DataForQuarkOperations(quarkOperationsArray, actionsArray)
         });
@@ -210,18 +213,21 @@ contract SwapActionsBuilder is QuarkBuilderBase {
         }
 
         (IQuarkWallet.QuarkOperation[] memory quarkOperationsArray, Actions.Action[] memory actionsArray) =
-        collectAssetsForAction({
-            actionIntent: actionIntent,
-            chainAccountsList: chainAccountsList,
-            payment: payment,
-            actionQuarkOperation: operation,
-            action: action
-        });
+            (new IQuarkWallet.QuarkOperation[](0), new Actions.Action[](0));
+        // (IQuarkWallet.QuarkOperation[] memory quarkOperationsArray, Actions.Action[] memory actionsArray) =
+        // collectAssetsForAction({
+        //     actionIntent: actionIntent,
+        //     chainAccountsList: chainAccountsList,
+        //     payment: payment,
+        //     actionQuarkOperation: operation,
+        //     action: action
+        // });
 
         return BuilderResult({
             version: VERSION,
             actions: actionsArray,
             quarkOperations: quarkOperationsArray,
+            simulations: new Simulation[](0),
             paymentCurrency: payment.currency,
             eip712Data: EIP712Helper.eip712DataForQuarkOperations(quarkOperationsArray, actionsArray)
         });

--- a/src/builder/actions/TransferActionsBuilder.sol
+++ b/src/builder/actions/TransferActionsBuilder.sol
@@ -31,7 +31,7 @@ contract TransferActionsBuilder is QuarkBuilderBase {
         TransferIntent memory transferIntent,
         Accounts.ChainAccounts[] memory chainAccountsList,
         PaymentInfo.Payment memory payment
-    ) external pure returns (BuilderResult memory) {
+    ) external view returns (BuilderResult memory) {
         // If the action is paid for with tokens, filter out any chain accounts that do not have corresponding payment information
         if (payment.isToken) {
             chainAccountsList = Accounts.findChainAccountsWithPaymentInfo(chainAccountsList, payment);
@@ -86,7 +86,7 @@ contract TransferActionsBuilder is QuarkBuilderBase {
         }
 
         (IQuarkWallet.QuarkOperation[] memory quarkOperationsArray, Actions.Action[] memory actionsArray) =
-        collectAssetsForAction({
+        simulateAndGetActions({
             actionIntent: actionIntent,
             chainAccountsList: chainAccountsList,
             payment: payment,

--- a/src/builder/actions/TransferActionsBuilder.sol
+++ b/src/builder/actions/TransferActionsBuilder.sol
@@ -30,12 +30,15 @@ contract TransferActionsBuilder is QuarkBuilderBase {
     function transfer(
         TransferIntent memory transferIntent,
         Accounts.ChainAccounts[] memory chainAccountsList,
-        PaymentInfo.Payment memory payment
+        string memory paymentCurrency
     ) external view returns (BuilderResult memory) {
+        bool paymentIsToken = PaymentInfo.knownToken(paymentCurrency, transferIntent.chainId);
+
+        // TODO: Why do we need this check?
         // If the action is paid for with tokens, filter out any chain accounts that do not have corresponding payment information
-        if (payment.isToken) {
-            chainAccountsList = Accounts.findChainAccountsWithPaymentInfo(chainAccountsList, payment);
-        }
+        // if (paymentIsToken) {
+        //     chainAccountsList = Accounts.findChainAccountsWithPaymentInfo(chainAccountsList, payment);
+        // }
 
         // Initialize TransferMax flag
         bool isMaxTransfer = transferIntent.amount == type(uint256).max;
@@ -45,9 +48,9 @@ contract TransferActionsBuilder is QuarkBuilderBase {
         // TODO: The intent shouldn't be changed! in the builder function we need to determine how much
         // amount out if it is max...
         // Convert transferIntent to user aggregated balance
-        if (isMaxTransfer) {
-            transferIntent.amount = Accounts.totalAvailableAsset(transferIntent.assetSymbol, chainAccountsList, payment);
-        }
+        // if (isMaxTransfer) {
+        //     transferIntent.amount = Accounts.totalAvailableAsset(transferIntent.assetSymbol, chainAccountsList, payment);
+        // }
 
         // Then, transfer `amount` of `assetSymbol` to `recipient`
         (IQuarkWallet.QuarkOperation memory operation, Actions.Action memory action) = Actions.transferAsset(

--- a/src/builder/actions/TransferActionsBuilder.sol
+++ b/src/builder/actions/TransferActionsBuilder.sol
@@ -42,6 +42,8 @@ contract TransferActionsBuilder is QuarkBuilderBase {
         // TransferMax will always use quotecall to avoid leaving dust in wallet
         bool useQuotecall = isMaxTransfer;
 
+        // TODO: The intent shouldn't be changed! in the builder function we need to determine how much
+        // amount out if it is max...
         // Convert transferIntent to user aggregated balance
         if (isMaxTransfer) {
             transferIntent.amount = Accounts.totalAvailableAsset(transferIntent.assetSymbol, chainAccountsList, payment);

--- a/src/builder/actions/TransferActionsBuilder.sol
+++ b/src/builder/actions/TransferActionsBuilder.sol
@@ -46,7 +46,7 @@ contract TransferActionsBuilder is QuarkBuilderBase {
         bool useQuotecall = isMaxTransfer;
 
         // TODO: The intent shouldn't be changed! in the builder function we need to determine how much
-        // amount out if it is max...
+        // amount out if it is max...ie. at this point, we don't know what payment max cost is
         // Convert transferIntent to user aggregated balance
         // if (isMaxTransfer) {
         //     transferIntent.amount = Accounts.totalAvailableAsset(transferIntent.assetSymbol, chainAccountsList, payment);

--- a/src/builder/actions/TransferActionsBuilder.sol
+++ b/src/builder/actions/TransferActionsBuilder.sol
@@ -85,8 +85,11 @@ contract TransferActionsBuilder is QuarkBuilderBase {
             });
         }
 
-        (IQuarkWallet.QuarkOperation[] memory quarkOperationsArray, Actions.Action[] memory actionsArray) =
-        simulateAndGetActions({
+        (
+            IQuarkWallet.QuarkOperation[] memory quarkOperationsArray,
+            Actions.Action[] memory actionsArray,
+            Simulation[] memory simulations
+        ) = simulateAndGetActions({
             actionIntent: actionIntent,
             chainAccountsList: chainAccountsList,
             payment: payment,
@@ -98,6 +101,7 @@ contract TransferActionsBuilder is QuarkBuilderBase {
             version: VERSION,
             actions: actionsArray,
             quarkOperations: quarkOperationsArray,
+            simulations: simulations,
             paymentCurrency: payment.currency,
             eip712Data: EIP712Helper.eip712DataForQuarkOperations(quarkOperationsArray, actionsArray)
         });

--- a/src/interfaces/IFFI.sol
+++ b/src/interfaces/IFFI.sol
@@ -11,4 +11,9 @@ interface IFFI {
         external
         pure
         returns (QuarkBuilderBase.Simulation[] memory);
+
+    function getGasPrices(string memory currencySymbol)
+        external
+        view
+        returns (QuarkBuilderBase.GasPricesResult memory);
 }

--- a/src/interfaces/IFFI.sol
+++ b/src/interfaces/IFFI.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity 0.8.27;
+
+import {Actions} from "src/builder/actions/Actions.sol";
+import {IQuarkWallet} from "quark-core/src/interfaces/IQuarkWallet.sol";
+import {QuarkBuilderBase} from "src/builder/QuarkBuilderBase.sol";
+
+/// @dev Interface for foreign function interface (FFI) contracts
+interface IFFI {
+    function simulate(IQuarkWallet.QuarkOperation[] memory quarkOperations, Actions.Action[] memory actionsArray)
+        external
+        pure
+        returns (QuarkBuilderBase.Simulation[] memory);
+}

--- a/test/builder/QuarkBuilderTransfer.t.sol
+++ b/test/builder/QuarkBuilderTransfer.t.sol
@@ -7,6 +7,7 @@ import "forge-std/console2.sol";
 
 import {QuarkBuilderTest} from "test/builder/lib/QuarkBuilderTest.sol";
 import {SimulationFFI} from "test/mocks/SimulationFFI.sol";
+import {GasPriceFFI} from "test/mocks/GasPriceFFI.sol";
 
 import {CCTPBridgeActions} from "src/BridgeScripts.sol";
 import {Multicall} from "src/Multicall.sol";
@@ -91,9 +92,19 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         });
     }
 
-    function setupSimulation() internal {
+    function setUp() external {
+        setupSimulationFFI();
+        setupGasEstimateFFI();
+    }
+
+    function setupSimulationFFI() internal {
         SimulationFFI mockFFI = new SimulationFFI();
         vm.etch(Actions.SIMULATION_FFI_ADDRESS, address(mockFFI).code);
+    }
+
+    function setupGasEstimateFFI() internal {
+        GasPriceFFI mockFFI = new GasPriceFFI();
+        vm.etch(Actions.GAS_PRICE_FFI_ADDRESS, address(mockFFI).code);
     }
 
     function testInsufficientFunds() public {
@@ -143,7 +154,6 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
 
     function testSimpleLocalTransferSucceeds() public {
         QuarkBuilder builder = new QuarkBuilder();
-        setupSimulation();
         QuarkBuilder.BuilderResult memory result = builder.transfer(
             transferUsdc_(1, 1e6, address(0xceecee), BLOCK_TIMESTAMP), // transfer 1 USDC on chain 1 to 0xceecee
             chainAccountsList_(3e6), // holding 3 USDC in total across chains 1, 8453
@@ -218,12 +228,11 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
 
     function testSimpleLocalTransferWithPaycallSucceeds() public {
         QuarkBuilder builder = new QuarkBuilder();
-        setupSimulation();
         PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](1);
         maxCosts[0] = PaymentInfo.PaymentMaxCost({chainId: 1, amount: 1e5});
         QuarkBuilder.BuilderResult memory result = builder.transfer(
             transferUsdc_(1, 1e6, address(0xceecee), BLOCK_TIMESTAMP), // transfer 1 usdc on chain 1 to 0xceecee
-            chainAccountsList_(3e6), // holding 3USDC on chains 1, 8453
+            chainAccountsList_(14e6), // holding 14USDC on chains 1, 8453
             paymentUsdc_(maxCosts)
         );
 
@@ -245,7 +254,7 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
                 Paycall.run.selector,
                 transferActionsAddress,
                 abi.encodeWithSelector(TransferActions.transferERC20Token.selector, usdc_(1), address(0xceecee), 1e6),
-                1.1e6
+                5562742 // Mock simulation cost
             ),
             "calldata is Paycall.run(TransferActions.transferERC20Token(USDC_1, address(0xceecee), 1e6), 20e6);"
         );
@@ -262,7 +271,7 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].actionType, "TRANSFER", "action type is 'TRANSFER'");
         assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
         assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC");
-        assertEq(result.actions[0].paymentMaxCost, 1e5, "payment max is set to 1e5 in this test case");
+        assertEq(result.actions[0].paymentMaxCost, 5562742, "payment max is set to 5562742 in this test case");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -443,12 +452,12 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
             transferToken_({
                 assetSymbol: "USDC",
                 chainId: 8453,
-                amount: 5e6,
+                amount: 12e6,
                 sender: address(0xb0b),
                 recipient: address(0xceecee),
                 blockTimestamp: BLOCK_TIMESTAMP
             }), // transfer 5 USDC on chain 8453 to 0xceecee
-            chainAccountsList_(6e6), // holding 6 USDC in total across chains 1, 8453
+            chainAccountsList_(20e6), // holding 6 USDC in total across chains 1, 8453
             paymentUsdc_(maxCosts)
         );
         address paycallAddress = paycallUsdc_(1);
@@ -472,12 +481,12 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
                 abi.encodeWithSelector(
                     CCTPBridgeActions.bridgeUSDC.selector,
                     address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155),
-                    2.1e6,
+                    2006409,
                     6,
                     bytes32(uint256(uint160(0xb0b))),
                     usdc_(1)
                 ),
-                0.5e6
+                5562742
             ),
             "calldata is Paycall.run(CCTPBridgeActions.bridgeUSDC(address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155), 2.1e6, 6, bytes32(uint256(uint160(0xb0b))), usdc_(1))), 5e5);"
         );
@@ -497,8 +506,10 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
             abi.encodeWithSelector(
                 Paycall.run.selector,
                 CodeJarHelper.getCodeAddress(type(TransferActions).creationCode),
-                abi.encodeWithSelector(TransferActions.transferERC20Token.selector, usdc_(8453), address(0xceecee), 5e6),
-                0.1e6
+                abi.encodeWithSelector(
+                    TransferActions.transferERC20Token.selector, usdc_(8453), address(0xceecee), 12e6
+                ),
+                6409
             ),
             "calldata is Paycall.run(TransferActions.transferERC20Token(USDC_8453, address(0xceecee), 5e6), 1e5);"
         );
@@ -515,14 +526,14 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].actionType, "BRIDGE", "action type is 'BRIDGE'");
         assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
         assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC on mainnet");
-        assertEq(result.actions[0].paymentMaxCost, 0.5e6, "payment should have max cost of 5e5");
+        assertEq(result.actions[0].paymentMaxCost, 5562742, "payment should have max cost of 5562742");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
             result.actions[0].actionContext,
             abi.encode(
                 Actions.BridgeActionContext({
-                    amount: 2.1e6,
+                    amount: 2006409,
                     price: USDC_PRICE,
                     token: USDC_1,
                     assetSymbol: "USDC",
@@ -539,14 +550,14 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         assertEq(result.actions[1].actionType, "TRANSFER", "action type is 'TRANSFER'");
         assertEq(result.actions[1].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
         assertEq(result.actions[1].paymentToken, USDC_8453, "payment token is USDC on Base");
-        assertEq(result.actions[1].paymentMaxCost, 0.1e6, "payment should have max cost of 1e5");
+        assertEq(result.actions[1].paymentMaxCost, 6409, "payment should have max cost of 6409");
         assertEq(result.actions[1].nonceSecret, BOB_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[1].totalPlays, 1, "total plays is 1");
         assertEq(
             result.actions[1].actionContext,
             abi.encode(
                 Actions.TransferActionContext({
-                    amount: 5e6,
+                    amount: 12e6,
                     price: USDC_PRICE,
                     token: USDC_8453,
                     assetSymbol: "USDC",
@@ -573,13 +584,13 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         QuarkBuilder.BuilderResult memory result = builder.transfer(
             transferToken_({
                 assetSymbol: "USDT",
-                chainId: 8453,
+                chainId: 1,
                 amount: 3e6,
                 sender: address(0xb0b),
                 recipient: address(0xceecee),
                 blockTimestamp: BLOCK_TIMESTAMP
             }), // transfer 3 USDT on chain 8453 to 0xceecee
-            chainAccountsList_(6e6), // holding 6 USDC and USDT in total across chains 1, 8453
+            chainAccountsList_(9e6), // USDC and USDT in total across chains 1, 8453
             paymentUsdc_(maxCosts)
         );
         address paycallAddress = paycallUsdc_(1);
@@ -592,7 +603,7 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         assertEq(result.quarkOperations.length, 2, "two operations");
         assertEq(
             result.quarkOperations[0].scriptAddress,
-            paycallAddress,
+            paycallAddressBase,
             "script address[0] has been wrapped with paycall address"
         );
         assertEq(
@@ -602,25 +613,25 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
                 cctpBridgeActionsAddress,
                 abi.encodeWithSelector(
                     CCTPBridgeActions.bridgeUSDC.selector,
-                    address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155),
-                    1.5e6,
-                    6,
+                    address(0x1682Ae6375C4E4A97e4B583BC394c861A46D8962),
+                    1062742,
+                    0,
                     bytes32(uint256(uint160(0xb0b))),
-                    usdc_(1)
+                    usdc_(8453)
                 ),
-                0.5e6
+                6409
             ),
             "calldata is Paycall.run(CCTPBridgeActions.bridgeUSDC(address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155), 1.5e6, 6, bytes32(uint256(uint160(0xb0b))), usdc_(1))), 0.5e6);"
         );
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
         );
-        assertEq(result.quarkOperations[0].nonce, ALICE_DEFAULT_SECRET, "unexpected nonce");
+        assertEq(result.quarkOperations[0].nonce, BOB_DEFAULT_SECRET, "unexpected nonce");
         assertEq(result.quarkOperations[0].isReplayable, false, "isReplayable is false");
 
         assertEq(
             result.quarkOperations[1].scriptAddress,
-            paycallAddressBase,
+            paycallAddress,
             "script address[1] has been wrapped with paycall address"
         );
         assertEq(
@@ -628,8 +639,8 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
             abi.encodeWithSelector(
                 Paycall.run.selector,
                 CodeJarHelper.getCodeAddress(type(TransferActions).creationCode),
-                abi.encodeWithSelector(TransferActions.transferERC20Token.selector, usdt_(8453), address(0xceecee), 3e6),
-                4.5e6
+                abi.encodeWithSelector(TransferActions.transferERC20Token.selector, usdt_(1), address(0xceecee), 3e6),
+                5562742
             ),
             "calldata is Paycall.run(TransferActions.transferERC20Token(USDT_8453, address(0xceecee), 3e6), 4.5e6);"
         );
@@ -641,36 +652,37 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
 
         // Check the actions
         assertEq(result.actions.length, 2, "one action");
-        assertEq(result.actions[0].chainId, 1, "operation is on chainid 1");
-        assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
+        assertEq(result.actions[0].chainId, 8453, "operation is on chainid 8453");
+        // TODO: It's not clear to me how this was A11ce before, seems should be b0b?
+        assertEq(result.actions[0].quarkAccount, address(0xb0b), "0xb0b sends the funds");
         assertEq(result.actions[0].actionType, "BRIDGE", "action type is 'BRIDGE'");
         assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC on mainnet");
-        assertEq(result.actions[0].paymentMaxCost, 0.5e6, "payment should have max cost of 0.5e6");
-        assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
+        assertEq(result.actions[0].paymentToken, USDC_8453, "payment token is USDC on base");
+        assertEq(result.actions[0].paymentMaxCost, 6409, "payment should have max cost of 6409");
+        assertEq(result.actions[0].nonceSecret, BOB_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
             result.actions[0].actionContext,
             abi.encode(
                 Actions.BridgeActionContext({
-                    amount: 1.5e6,
+                    amount: 1062742,
                     price: USDC_PRICE,
-                    token: USDC_1,
+                    token: USDC_8453,
                     assetSymbol: "USDC",
-                    chainId: 1,
+                    chainId: 8453,
                     recipient: address(0xb0b),
-                    destinationChainId: 8453,
+                    destinationChainId: 1,
                     bridgeType: Actions.BRIDGE_TYPE_CCTP
                 })
             ),
             "action context encoded from BridgeActionContext"
         );
-        assertEq(result.actions[1].chainId, 8453, "operation is on chainid 8453");
+        assertEq(result.actions[1].chainId, 1, "operation is on chainid 8453");
         assertEq(result.actions[1].quarkAccount, address(0xb0b), "0xb0b sends the funds");
         assertEq(result.actions[1].actionType, "TRANSFER", "action type is 'TRANSFER'");
         assertEq(result.actions[1].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[1].paymentToken, USDC_8453, "payment token is USDC on Base");
-        assertEq(result.actions[1].paymentMaxCost, 4.5e6, "payment should have max cost of 4.5e6");
+        assertEq(result.actions[1].paymentToken, USDC_1, "payment token is USDC on Mainnet");
+        assertEq(result.actions[1].paymentMaxCost, 5562742, "payment should have max cost of 5562742");
         assertEq(result.actions[1].nonceSecret, BOB_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[1].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -679,9 +691,9 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
                 Actions.TransferActionContext({
                     amount: 3e6,
                     price: USDT_PRICE,
-                    token: USDT_8453,
+                    token: USDT_1,
                     assetSymbol: "USDT",
-                    chainId: 8453,
+                    chainId: 1,
                     recipient: address(0xceecee)
                 })
             ),

--- a/test/mocks/GasPriceFFI.sol
+++ b/test/mocks/GasPriceFFI.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity 0.8.27;
+
+import "../../src/builder/Strings.sol";
+import {QuarkBuilderBase} from "src/builder/QuarkBuilderBase.sol";
+
+contract GasPriceFFI {
+    // TODO: Update to pass in list of chainIds
+    function getGasPrices(
+        string memory currency
+    ) external pure returns (QuarkBuilderBase.GasPricesResult memory) {
+        QuarkBuilderBase.GasPricesResult memory result;
+        result.currency = currency;
+        if (Strings.stringEq(currency, "usdc")) {
+            result.currencyPrice = 2500 * 1e6;
+        } else {
+            revert("Unsupported currency");
+        }
+
+        uint256[] memory chainIds = new uint256[](2);
+        chainIds[0] = 1;
+        chainIds[1] = 8453;
+
+        QuarkBuilderBase.GasPrice[]
+            memory gasPrices = new QuarkBuilderBase.GasPrice[](chainIds.length);
+        for (uint256 i = 0; i < chainIds.length; i++) {
+            if (chainIds[i] == 1) {
+                gasPrices[i].chainId = 1;
+                gasPrices[i].ethGasPrice = 8607726355;
+            } else {
+                gasPrices[i].chainId = 8453;
+                gasPrices[i].ethGasPrice = 9919085;
+            }
+        }
+        result.gasPrices = gasPrices;
+
+        return result;
+    }
+}

--- a/test/mocks/SimulationFFI.sol
+++ b/test/mocks/SimulationFFI.sol
@@ -7,8 +7,7 @@ import {QuarkBuilderBase} from "src/builder/QuarkBuilderBase.sol";
 import "../../src/builder/Strings.sol";
 
 contract SimulationFFI {
-    // Using the array of quark operations and actions, we can generate all the data required
-    // for the simulate call
+    // Mock simulate FFI implementation
     function simulate(IQuarkWallet.QuarkOperation[] memory quarkOperations, Actions.Action[] memory actionsArray)
         external
         pure
@@ -32,6 +31,7 @@ contract SimulationFFI {
                 currencyScale = 1e2;
             } else {
                 currencyScale = 1e6;
+                operationGasUsed += 135_000; // Estimated paycall buffer
             }
 
             uint256 operationCurrencyEstimate = operationGasUsed * gasPrice * ethPriceInUSD * currencyScale / 1e18;

--- a/test/mocks/SimulationFFI.sol
+++ b/test/mocks/SimulationFFI.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity 0.8.27;
+
+import {Actions} from "src/builder/actions/Actions.sol";
+import {IQuarkWallet} from "quark-core/src/interfaces/IQuarkWallet.sol";
+import {QuarkBuilderBase} from "src/builder/QuarkBuilderBase.sol";
+import "../../src/builder/Strings.sol";
+
+contract SimulationFFI {
+    // Using the array of quark operations and actions, we can generate all the data required
+    // for the simulate call
+    function simulate(IQuarkWallet.QuarkOperation[] memory quarkOperations, Actions.Action[] memory actionsArray)
+        external
+        pure
+        returns (QuarkBuilderBase.Simulation[] memory)
+    {
+        QuarkBuilderBase.Simulation[] memory simulations = new QuarkBuilderBase.Simulation[](quarkOperations.length);
+        for (uint256 i = 0; i < quarkOperations.length; i++) {
+            Actions.Action memory action = actionsArray[i];
+
+            uint256 gasPrice;
+            if (action.chainId == 1) {
+                gasPrice = 8607726355;
+            } else {
+                gasPrice = 9919085;
+            }
+            uint256 operationGasUsed = 100000;
+            uint256 ethPriceInUSD = 2500;
+
+            uint256 currencyScale;
+            if (Strings.stringEq(action.paymentMethod, "OFFCHAIN")) {
+                currencyScale = 1e2;
+            } else {
+                currencyScale = 1e6;
+            }
+
+            uint256 operationCurrencyEstimate = operationGasUsed * gasPrice * ethPriceInUSD * currencyScale / 1e18;
+            if (operationCurrencyEstimate == 0) {
+                operationCurrencyEstimate = 1;
+            }
+
+            simulations[i] = QuarkBuilderBase.Simulation({
+                chainId: action.chainId,
+                currency: getPaymentCurrency(action),
+                operationGasUsed: operationGasUsed,
+                factoryGasUsed: 0,
+                ethGasPrice: gasPrice,
+                operationCurrencyEstimate: operationCurrencyEstimate,
+                factoryCurrencyEstimate: 0,
+                currencyEstimate: operationCurrencyEstimate
+            });
+        }
+        return simulations;
+    }
+
+    function getPaymentCurrency(Actions.Action memory action) internal pure returns (string memory currency) {
+        if (Strings.stringEq(action.paymentMethod, "OFFCHAIN")) {
+            currency = "usd";
+        } else {
+            currency = "usdc";
+        }
+    }
+}


### PR DESCRIPTION
Currently, the logic for multi-step simulation for paycall transactions is all done on the client side. This PR aims to move this logic into QuarkBuilder by making a call to a simulation ffi. ie. when calling the builder with an intent which uses paycall, the builder first simulates the transaction to get the estimated max payment cost and then uses the estimate for building up the transaction with paycall