### PR TITLE
Add "wrap/unwrap all" functions; always wrap/unwrap all in QuarkBuilder

### DIFF
--- a/src/WrapperScripts.sol
+++ b/src/WrapperScripts.sol
@@ -10,6 +10,13 @@ contract WrapperActions {
         IWETH(weth).deposit{value: amount}();
     }
 
+    function wrapETHUpTo(address weth, uint256 targetAmount) external payable {
+        uint256 currentBalance = IERC20(weth).balanceOf(address(this));
+        if (currentBalance < targetAmount) {
+            IWETH(weth).deposit{value: targetAmount - currentBalance}();
+        }
+    }
+
     function wrapAllETH(address weth) external payable {
         uint256 ethBalance = address(this).balance;
         if (ethBalance > 0) {
@@ -19,6 +26,13 @@ contract WrapperActions {
 
     function unwrapWETH(address weth, uint256 amount) external {
         IWETH(weth).withdraw(amount);
+    }
+
+    function unwrapWETHUpTo(address weth, uint256 targetAmount) external {
+        uint256 currentBalance = address(this).balance;
+        if (currentBalance < targetAmount) {
+            IWETH(weth).withdraw(targetAmount - currentBalance);
+        }
     }
 
     function unwrapAllWETH(address weth) external payable {

--- a/src/WrapperScripts.sol
+++ b/src/WrapperScripts.sol
@@ -10,10 +10,10 @@ contract WrapperActions {
         IWETH(weth).deposit{value: amount}();
     }
 
-    function wrapETHUpTo(address weth, uint256 targetAmount) external payable {
-        uint256 currentBalance = IERC20(weth).balanceOf(address(this));
-        if (currentBalance < targetAmount) {
-            IWETH(weth).deposit{value: targetAmount - currentBalance}();
+    function wrapAllETH(address weth) external payable {
+        uint256 ethBalance = address(this).balance;
+        if (ethBalance > 0) {
+            IWETH(weth).deposit{value: ethBalance}();
         }
     }
 
@@ -21,10 +21,10 @@ contract WrapperActions {
         IWETH(weth).withdraw(amount);
     }
 
-    function unwrapWETHUpTo(address weth, uint256 targetAmount) external {
-        uint256 currentBalance = address(this).balance;
-        if (currentBalance < targetAmount) {
-            IWETH(weth).withdraw(targetAmount - currentBalance);
+    function unwrapAllWETH(address weth) external payable {
+        uint256 wethBalance = IERC20(weth).balanceOf(address(this));
+        if (wethBalance > 0) {
+            IWETH(weth).withdraw(wethBalance);
         }
     }
 
@@ -33,7 +33,22 @@ contract WrapperActions {
         IWstETH(wstETH).wrap(amount);
     }
 
+    function wrapAllLidoStETH(address wstETH, address stETH) external payable {
+        uint256 stETHBalance = IERC20(stETH).balanceOf(address(this));
+        if (stETHBalance > 0) {
+            IERC20(stETH).approve(wstETH, stETHBalance);
+            IWstETH(wstETH).wrap(stETHBalance);
+        }
+    }
+
     function unwrapLidoWstETH(address wstETH, uint256 amount) external {
         IWstETH(wstETH).unwrap(amount);
+    }
+
+    function unwrapAllLidoWstETH(address wstETH) external {
+        uint256 wstETHBalance = IERC20(wstETH).balanceOf(address(this));
+        if (wstETHBalance > 0) {
+            IWstETH(wstETH).unwrap(wstETHBalance);
+        }
     }
 }

--- a/src/builder/BridgeRoutes.sol
+++ b/src/builder/BridgeRoutes.sol
@@ -208,7 +208,7 @@ library Across {
         uint256 bridgedAmount = HashMap.contains(assetsBridged, abi.encode(assetSymbol))
             ? HashMap.getUint256(assetsBridged, abi.encode(assetSymbol))
             : 0;
-        return bridgedAmount != 0
+        return bridgedAmount > 0
             && (Strings.stringEqIgnoreCase(assetSymbol, "ETH") || Strings.stringEqIgnoreCase(assetSymbol, "WETH"));
     }
 }

--- a/src/builder/BridgeRoutes.sol
+++ b/src/builder/BridgeRoutes.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.27;
 import {AcrossActions} from "src/AcrossScripts.sol";
 import {CCTPBridgeActions} from "src/BridgeScripts.sol";
 import {Errors} from "src/builder/Errors.sol";
+import {HashMap} from "src/builder/HashMap.sol";
 import {QuarkBuilder} from "src/builder/QuarkBuilder.sol";
 
 import "src/builder/Strings.sol";
@@ -195,5 +196,19 @@ library Across {
                 useNativeToken // useNativeToken
             )
         );
+    }
+
+    // Returns whether or not an asset is bridged non-deterministically. This applies to WETH/ETH, where Across will send either ETH or WETH
+    // to the target address depending on if address is an EOA or contract.
+    function isNonDeterministicBridgeAction(HashMap.Map memory assetsBridged, string memory assetSymbol)
+        internal
+        pure
+        returns (bool)
+    {
+        uint256 bridgedAmount = HashMap.contains(assetsBridged, abi.encode(assetSymbol))
+            ? HashMap.getUint256(assetsBridged, abi.encode(assetSymbol))
+            : 0;
+        return bridgedAmount != 0
+            && (Strings.stringEqIgnoreCase(assetSymbol, "ETH") || Strings.stringEqIgnoreCase(assetSymbol, "WETH"));
     }
 }

--- a/src/builder/QuarkBuilderBase.sol
+++ b/src/builder/QuarkBuilderBase.sol
@@ -432,8 +432,8 @@ contract QuarkBuilderBase {
                 Actions.WrapOrUnwrapAsset({
                     chainAccountsList: chainAccountsList,
                     assetSymbol: counterpartSymbol,
-                    // This is just to indicate we plan to wrap all
-                    amount: type(uint256).max,
+                    // Note: The wrapper logic should only "wrap all" or "wrap up to" the amount needed
+                    amount: amountNeeded,
                     chainId: chainId,
                     sender: account,
                     blockTimestamp: blockTimestamp

--- a/src/builder/QuarkBuilderBase.sol
+++ b/src/builder/QuarkBuilderBase.sol
@@ -37,7 +37,7 @@ contract QuarkBuilderBase {
 
     /* ===== Constants ===== */
 
-    string constant VERSION = "0.2.1";
+    string constant VERSION = "0.3.0";
 
     /* ===== Custom Errors ===== */
 

--- a/src/builder/TokenWrapper.sol
+++ b/src/builder/TokenWrapper.sol
@@ -108,67 +108,50 @@ library TokenWrapper {
         return Strings.stringEqIgnoreCase(tokenSymbol, getKnownWrapperTokenPair(chainId, tokenSymbol).wrappedSymbol);
     }
 
-    function encodeActionToWrapOrUnwrap(uint256 chainId, string memory tokenSymbol, uint256 amount, bool useWrapUpTo)
+    function encodeActionToWrapOrUnwrap(uint256 chainId, string memory tokenSymbol)
         internal
         pure
         returns (bytes memory)
     {
         KnownWrapperTokenPair memory pair = getKnownWrapperTokenPair(chainId, tokenSymbol);
         if (isWrappedToken(chainId, tokenSymbol)) {
-            return encodeActionToUnwrapToken(chainId, tokenSymbol, amount, useWrapUpTo);
+            return encodeActionToUnwrapToken(chainId, tokenSymbol);
         } else {
-            return encodeActionToWrapToken(chainId, tokenSymbol, pair.underlyingToken, amount, useWrapUpTo);
+            return encodeActionToWrapToken(chainId, tokenSymbol, pair.underlyingToken);
         }
     }
 
-    function encodeActionToWrapToken(
-        uint256 chainId,
-        string memory tokenSymbol,
-        address tokenAddress,
-        uint256 amount,
-        bool useWrapUpTo
-    ) internal pure returns (bytes memory) {
+    function encodeActionToWrapToken(uint256 chainId, string memory tokenSymbol, address tokenAddress)
+        internal
+        pure
+        returns (bytes memory)
+    {
         if (Strings.stringEqIgnoreCase(tokenSymbol, "ETH")) {
-            if (useWrapUpTo) {
-                return abi.encodeWithSelector(
-                    WrapperActions.wrapETHUpTo.selector, getKnownWrapperTokenPair(chainId, tokenSymbol).wrapper, amount
-                );
-            } else {
-                return abi.encodeWithSelector(
-                    WrapperActions.wrapETH.selector, getKnownWrapperTokenPair(chainId, tokenSymbol).wrapper, amount
-                );
-            }
+            return abi.encodeWithSelector(
+                WrapperActions.wrapAllETH.selector, getKnownWrapperTokenPair(chainId, tokenSymbol).wrapper
+            );
         } else if (Strings.stringEqIgnoreCase(tokenSymbol, "stETH")) {
             return abi.encodeWithSelector(
-                WrapperActions.wrapLidoStETH.selector,
+                WrapperActions.wrapAllLidoStETH.selector,
                 getKnownWrapperTokenPair(chainId, tokenSymbol).wrapper,
-                tokenAddress,
-                amount
+                tokenAddress
             );
         }
         revert NotWrappable();
     }
 
-    function encodeActionToUnwrapToken(uint256 chainId, string memory tokenSymbol, uint256 amount, bool useWrapUpTo)
+    function encodeActionToUnwrapToken(uint256 chainId, string memory tokenSymbol)
         internal
         pure
         returns (bytes memory)
     {
         if (Strings.stringEqIgnoreCase(tokenSymbol, "WETH")) {
-            if (useWrapUpTo) {
-                return abi.encodeWithSelector(
-                    WrapperActions.unwrapWETHUpTo.selector,
-                    getKnownWrapperTokenPair(chainId, tokenSymbol).wrapper,
-                    amount
-                );
-            } else {
-                return abi.encodeWithSelector(
-                    WrapperActions.unwrapWETH.selector, getKnownWrapperTokenPair(chainId, tokenSymbol).wrapper, amount
-                );
-            }
+            return abi.encodeWithSelector(
+                WrapperActions.unwrapAllWETH.selector, getKnownWrapperTokenPair(chainId, tokenSymbol).wrapper
+            );
         } else if (Strings.stringEqIgnoreCase(tokenSymbol, "wstETH")) {
             return abi.encodeWithSelector(
-                WrapperActions.unwrapLidoWstETH.selector, getKnownWrapperTokenPair(chainId, tokenSymbol).wrapper, amount
+                WrapperActions.unwrapAllLidoWstETH.selector, getKnownWrapperTokenPair(chainId, tokenSymbol).wrapper
             );
         }
         revert NotUnwrappable();

--- a/src/builder/actions/Actions.sol
+++ b/src/builder/actions/Actions.sol
@@ -1490,7 +1490,9 @@ library Actions {
             nonce: accountSecret.nonceSecret,
             isReplayable: false,
             scriptAddress: CodeJarHelper.getCodeAddress(type(WrapperActions).creationCode),
-            scriptCalldata: TokenWrapper.encodeActionToWrapOrUnwrap(wrapOrUnwrap.chainId, wrapOrUnwrap.assetSymbol),
+            scriptCalldata: TokenWrapper.encodeActionToWrapOrUnwrap(
+                wrapOrUnwrap.chainId, wrapOrUnwrap.assetSymbol, wrapOrUnwrap.amount
+                ),
             scriptSources: scriptSources,
             expiry: wrapOrUnwrap.blockTimestamp + STANDARD_EXPIRY_BUFFER
         });

--- a/src/builder/actions/Actions.sol
+++ b/src/builder/actions/Actions.sol
@@ -118,6 +118,7 @@ library Actions {
         uint256 amount;
         uint256 chainId;
         address sender;
+        bool useWrapUpTo;
         uint256 blockTimestamp;
     }
 
@@ -1491,7 +1492,7 @@ library Actions {
             isReplayable: false,
             scriptAddress: CodeJarHelper.getCodeAddress(type(WrapperActions).creationCode),
             scriptCalldata: TokenWrapper.encodeActionToWrapOrUnwrap(
-                wrapOrUnwrap.chainId, wrapOrUnwrap.assetSymbol, wrapOrUnwrap.amount
+                wrapOrUnwrap.chainId, wrapOrUnwrap.assetSymbol, wrapOrUnwrap.amount, wrapOrUnwrap.useWrapUpTo
                 ),
             scriptSources: scriptSources,
             expiry: wrapOrUnwrap.blockTimestamp + STANDARD_EXPIRY_BUFFER

--- a/src/builder/actions/Actions.sol
+++ b/src/builder/actions/Actions.sol
@@ -118,7 +118,6 @@ library Actions {
         uint256 amount;
         uint256 chainId;
         address sender;
-        bool useWrapUpTo;
         uint256 blockTimestamp;
     }
 
@@ -1491,9 +1490,7 @@ library Actions {
             nonce: accountSecret.nonceSecret,
             isReplayable: false,
             scriptAddress: CodeJarHelper.getCodeAddress(type(WrapperActions).creationCode),
-            scriptCalldata: TokenWrapper.encodeActionToWrapOrUnwrap(
-                wrapOrUnwrap.chainId, wrapOrUnwrap.assetSymbol, wrapOrUnwrap.amount, wrapOrUnwrap.useWrapUpTo
-                ),
+            scriptCalldata: TokenWrapper.encodeActionToWrapOrUnwrap(wrapOrUnwrap.chainId, wrapOrUnwrap.assetSymbol),
             scriptSources: scriptSources,
             expiry: wrapOrUnwrap.blockTimestamp + STANDARD_EXPIRY_BUFFER
         });

--- a/src/interfaces/IWstETH.sol
+++ b/src/interfaces/IWstETH.sol
@@ -2,6 +2,6 @@
 pragma solidity 0.8.27;
 
 interface IWstETH {
-    function wrap(uint256 amount) external returns (uint256);
-    function unwrap(uint256 amount) external returns (uint256);
+    function wrap(uint256 stETHAmount) external returns (uint256);
+    function unwrap(uint256 wstETHAmount) external returns (uint256);
 }

--- a/test/WrapperScripts.t.sol
+++ b/test/WrapperScripts.t.sol
@@ -65,6 +65,56 @@ contract WrapperScriptsTest is Test {
         assertEq(address(wallet).balance, 0 ether);
     }
 
+    function testWrapETHUpTo() public {
+        vm.pauseGasMetering();
+        QuarkWallet wallet = QuarkWallet(factory.create(alice, address(0)));
+
+        deal(address(wallet), 10 ether);
+        deal(WETH, address(wallet), 7 ether);
+
+        QuarkWallet.QuarkOperation memory op = new QuarkOperationHelper().newBasicOpWithCalldata(
+            wallet,
+            wrapperScript,
+            abi.encodeWithSelector(WrapperActions.wrapETHUpTo.selector, WETH, 10 ether),
+            ScriptType.ScriptSource
+        );
+        bytes memory signature = new SignatureHelper().signOp(alicePrivateKey, wallet, op);
+
+        assertEq(IERC20(WETH).balanceOf(address(wallet)), 7 ether);
+        assertEq(address(wallet).balance, 10 ether);
+
+        vm.resumeGasMetering();
+        wallet.executeQuarkOperation(op, signature);
+
+        assertEq(IERC20(WETH).balanceOf(address(wallet)), 10 ether);
+        assertEq(address(wallet).balance, 7 ether);
+    }
+
+    function testWrapETHUpToDoesNotWrapIfNotNeeded() public {
+        vm.pauseGasMetering();
+        QuarkWallet wallet = QuarkWallet(factory.create(alice, address(0)));
+
+        deal(address(wallet), 10 ether);
+        deal(WETH, address(wallet), 10 ether);
+
+        QuarkWallet.QuarkOperation memory op = new QuarkOperationHelper().newBasicOpWithCalldata(
+            wallet,
+            wrapperScript,
+            abi.encodeWithSelector(WrapperActions.wrapETHUpTo.selector, WETH, 10 ether),
+            ScriptType.ScriptSource
+        );
+        bytes memory signature = new SignatureHelper().signOp(alicePrivateKey, wallet, op);
+
+        assertEq(IERC20(WETH).balanceOf(address(wallet)), 10 ether);
+        assertEq(address(wallet).balance, 10 ether);
+
+        vm.resumeGasMetering();
+        wallet.executeQuarkOperation(op, signature);
+
+        assertEq(IERC20(WETH).balanceOf(address(wallet)), 10 ether);
+        assertEq(address(wallet).balance, 10 ether);
+    }
+
     function testWrapAllETH() public {
         vm.pauseGasMetering();
         QuarkWallet wallet = QuarkWallet(factory.create(alice, address(0)));
@@ -109,6 +159,56 @@ contract WrapperScriptsTest is Test {
         vm.resumeGasMetering();
         wallet.executeQuarkOperation(op, signature);
         assertEq(IERC20(WETH).balanceOf(address(wallet)), 0 ether);
+        assertEq(address(wallet).balance, 10 ether);
+    }
+
+    function testUnwrapWETHUpTo() public {
+        vm.pauseGasMetering();
+        QuarkWallet wallet = QuarkWallet(factory.create(alice, address(0)));
+
+        deal(WETH, address(wallet), 10 ether);
+        deal(address(wallet), 7 ether);
+
+        QuarkWallet.QuarkOperation memory op = new QuarkOperationHelper().newBasicOpWithCalldata(
+            wallet,
+            wrapperScript,
+            abi.encodeWithSelector(WrapperActions.unwrapWETHUpTo.selector, WETH, 10 ether),
+            ScriptType.ScriptSource
+        );
+        bytes memory signature = new SignatureHelper().signOp(alicePrivateKey, wallet, op);
+
+        assertEq(IERC20(WETH).balanceOf(address(wallet)), 10 ether);
+        assertEq(address(wallet).balance, 7 ether);
+
+        vm.resumeGasMetering();
+        wallet.executeQuarkOperation(op, signature);
+
+        assertEq(IERC20(WETH).balanceOf(address(wallet)), 7 ether);
+        assertEq(address(wallet).balance, 10 ether);
+    }
+
+    function testUnwrapWETHUpToDoesNotUnwrapIfNotNeeded() public {
+        vm.pauseGasMetering();
+        QuarkWallet wallet = QuarkWallet(factory.create(alice, address(0)));
+
+        deal(WETH, address(wallet), 10 ether);
+        deal(address(wallet), 10 ether);
+
+        QuarkWallet.QuarkOperation memory op = new QuarkOperationHelper().newBasicOpWithCalldata(
+            wallet,
+            wrapperScript,
+            abi.encodeWithSelector(WrapperActions.unwrapWETHUpTo.selector, WETH, 10 ether),
+            ScriptType.ScriptSource
+        );
+        bytes memory signature = new SignatureHelper().signOp(alicePrivateKey, wallet, op);
+
+        assertEq(IERC20(WETH).balanceOf(address(wallet)), 10 ether);
+        assertEq(address(wallet).balance, 10 ether);
+
+        vm.resumeGasMetering();
+        wallet.executeQuarkOperation(op, signature);
+
+        assertEq(IERC20(WETH).balanceOf(address(wallet)), 10 ether);
         assertEq(address(wallet).balance, 10 ether);
     }
 

--- a/test/builder/BridgingLogic.t.sol
+++ b/test/builder/BridgingLogic.t.sol
@@ -136,13 +136,13 @@ contract BridgingLogicTest is Test, QuarkBuilderTest {
         callContracts[1] = transferActionsAddress;
         bytes[] memory callDatas = new bytes[](2);
         callDatas[0] = abi.encodeWithSelector(
-            WrapperActions.wrapETHUpTo.selector, TokenWrapper.getKnownWrapperTokenPair(8453, "WETH").wrapper, 1e18
+            WrapperActions.wrapAllETH.selector, TokenWrapper.getKnownWrapperTokenPair(8453, "WETH").wrapper
         );
         callDatas[1] = abi.encodeCall(TransferActions.transferERC20Token, (weth_(8453), address(0xceecee), 1e18));
         assertEq(
             result.quarkOperations[1].scriptCalldata,
             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-            "calldata is Multicall.run([wrapperActionsAddress, transferActionsAddress], [WrapperActions.wrapETHUpTo(USDC_8453, 1e18),  TransferActions.transferERC20Token(USDC_8453, address(0xceecee), 1e18))"
+            "calldata is Multicall.run([wrapperActionsAddress, transferActionsAddress], [WrapperActions.wrapAllETH(USDC_8453),  TransferActions.transferERC20Token(USDC_8453, address(0xceecee), 1e18))"
         );
         assertEq(
             result.quarkOperations[1].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"

--- a/test/builder/BridgingLogic.t.sol
+++ b/test/builder/BridgingLogic.t.sol
@@ -23,14 +23,15 @@ import {PaymentInfo} from "src/builder/PaymentInfo.sol";
 import {QuarkBuilder} from "src/builder/QuarkBuilder.sol";
 import {QuarkBuilderBase} from "src/builder/QuarkBuilderBase.sol";
 import {Quotecall} from "src/Quotecall.sol";
+import {TokenWrapper} from "src/builder/TokenWrapper.sol";
 import {YulHelper} from "test/lib/YulHelper.sol";
 
-import {AcrossFFI} from "test/builder/mocks/AcrossFFI.sol";
+import {MockAcrossFFI, MockAcrossFFIConstants} from "test/builder/mocks/AcrossFFI.sol";
 
 contract BridgingLogicTest is Test, QuarkBuilderTest {
     function setUp() public {
         // Deploy mock FFI for calling Across API
-        AcrossFFI mockFFI = new AcrossFFI();
+        MockAcrossFFI mockFFI = new MockAcrossFFI();
         vm.etch(FFI.ACROSS_FFI_ADDRESS, address(mockFFI).code);
     }
 
@@ -48,7 +49,7 @@ contract BridgingLogicTest is Test, QuarkBuilderTest {
         chainAccountsList[1] = Accounts.ChainAccounts({
             chainId: 8453,
             quarkSecrets: quarkSecrets_(address(0xb0b), bytes32(uint256(2))),
-            assetPositionsList: assetPositionsList_(8453, address(0xb0b), 0e18),
+            assetPositionsList: assetPositionsList_(8453, address(0xb0b), 0.5e18),
             cometPositions: emptyCometPositions_(),
             morphoPositions: emptyMorphoPositions_(),
             morphoVaultPositions: emptyMorphoVaultPositions_()
@@ -69,6 +70,10 @@ contract BridgingLogicTest is Test, QuarkBuilderTest {
         );
 
         assertEq(result.paymentCurrency, "usd", "usd currency");
+
+        address multicallAddress = CodeJarHelper.getCodeAddress(type(Multicall).creationCode);
+        address wrapperActionsAddress = CodeJarHelper.getCodeAddress(type(WrapperActions).creationCode);
+        address transferActionsAddress = CodeJarHelper.getCodeAddress(type(TransferActions).creationCode);
 
         // Check the quark operations
         assertEq(result.quarkOperations.length, 2, "two operations");
@@ -102,8 +107,8 @@ contract BridgingLogicTest is Test, QuarkBuilderTest {
                     address(0xb0b), // recipient
                     weth_(1), // inputToken
                     weth_(8453), // outputToken
-                    1e18 * (1e18 + 0.01e18) / 1e18 + 1e6, // inputAmount
-                    1e18, // outputAmount
+                    0.5e18 * (1e18 + MockAcrossFFIConstants.VARIABLE_FEE_PCT) / 1e18 + MockAcrossFFIConstants.GAS_FEE, // inputAmount
+                    0.5e18, // outputAmount
                     8453, // destinationChainId
                     address(0), // exclusiveRelayer
                     uint32(BLOCK_TIMESTAMP) - Across.QUOTE_TIMESTAMP_BUFFER, // quoteTimestamp
@@ -123,28 +128,21 @@ contract BridgingLogicTest is Test, QuarkBuilderTest {
 
         assertEq(
             result.quarkOperations[1].scriptAddress,
-            address(
-                uint160(
-                    uint256(
-                        keccak256(
-                            abi.encodePacked(
-                                bytes1(0xff),
-                                /* codeJar address */
-                                address(CodeJarHelper.CODE_JAR_ADDRESS),
-                                uint256(0),
-                                /* script bytecode */
-                                keccak256(type(TransferActions).creationCode)
-                            )
-                        )
-                    )
-                )
-            ),
-            "script address for transfer is correct given the code jar address"
+            multicallAddress,
+            "script address for Multicall is correct given the code jar address"
         );
+        address[] memory callContracts = new address[](2);
+        callContracts[0] = wrapperActionsAddress;
+        callContracts[1] = transferActionsAddress;
+        bytes[] memory callDatas = new bytes[](2);
+        callDatas[0] = abi.encodeWithSelector(
+            WrapperActions.wrapETHUpTo.selector, TokenWrapper.getKnownWrapperTokenPair(8453, "WETH").wrapper, 1e18
+        );
+        callDatas[1] = abi.encodeCall(TransferActions.transferERC20Token, (weth_(8453), address(0xceecee), 1e18));
         assertEq(
             result.quarkOperations[1].scriptCalldata,
-            abi.encodeCall(TransferActions.transferERC20Token, (weth_(8453), address(0xceecee), 1e18)),
-            "calldata is TransferActions.transferERC20Token(USDC_8453, address(0xceecee), 5e6);"
+            abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
+            "calldata is Multicall.run([wrapperActionsAddress, transferActionsAddress], [WrapperActions.wrapETHUpTo(USDC_8453, 1e18),  TransferActions.transferERC20Token(USDC_8453, address(0xceecee), 1e18))"
         );
         assertEq(
             result.quarkOperations[1].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
@@ -169,8 +167,9 @@ contract BridgingLogicTest is Test, QuarkBuilderTest {
                     price: WETH_PRICE,
                     token: WETH_1,
                     assetSymbol: "WETH",
-                    inputAmount: 1e18 * (1e18 + 0.01e18) / 1e18 + 1e6,
-                    outputAmount: 1e18,
+                    inputAmount: 0.5e18 * (1e18 + MockAcrossFFIConstants.VARIABLE_FEE_PCT) / 1e18
+                        + MockAcrossFFIConstants.GAS_FEE,
+                    outputAmount: 0.5e18,
                     chainId: 1,
                     recipient: address(0xb0b),
                     destinationChainId: 8453,

--- a/test/builder/QuarkBuilderCometBorrow.t.sol
+++ b/test/builder/QuarkBuilderCometBorrow.t.sol
@@ -264,7 +264,7 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
         callContracts[1] = cometSupplyMultipleAssetsAndBorrowAddress;
         bytes[] memory callDatas = new bytes[](2);
         callDatas[0] =
-            abi.encodeWithSelector(WrapperActions.wrapETH.selector, 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, 1e18);
+            abi.encodeWithSelector(WrapperActions.wrapAllETH.selector, 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
         callDatas[1] = abi.encodeCall(
             CometSupplyMultipleAssetsAndBorrow.run, (cometUsdc_(1), collateralTokens, collateralAmounts, usdc_(1), 1e6)
         );
@@ -272,7 +272,7 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-            "calldata is Multicall.run([wrapperActionsAddress, cometSupplyMultipleAssetsAndBorrowAddress], [WrapperActions.wrapWETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, 10e18), CometSupplyMultipleAssetsAndBorrow.run(COMET_1, collateralTokens, collateralAmounts, usdc_(1), 1e6)"
+            "calldata is Multicall.run([wrapperActionsAddress, cometSupplyMultipleAssetsAndBorrowAddress], [WrapperActions.wrapAllETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2), CometSupplyMultipleAssetsAndBorrow.run(COMET_1, collateralTokens, collateralAmounts, usdc_(1), 1e6)"
         );
         assertEq(result.quarkOperations[0].scriptSources.length, 3);
         assertEq(result.quarkOperations[0].scriptSources[0], type(WrapperActions).creationCode);

--- a/test/builder/QuarkBuilderCometRepay.t.sol
+++ b/test/builder/QuarkBuilderCometRepay.t.sol
@@ -292,7 +292,7 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
         callContracts[1] = cometRepayAndWithdrawMultipleAssetsAddress;
         bytes[] memory callDatas = new bytes[](2);
         callDatas[0] =
-            abi.encodeWithSelector(WrapperActions.wrapETH.selector, 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, 1e18);
+            abi.encodeWithSelector(WrapperActions.wrapAllETH.selector, 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
         callDatas[1] = abi.encodeCall(
             CometRepayAndWithdrawMultipleAssets.run,
             (cometWeth_(1), collateralTokens, collateralAmounts, weth_(1), 1e18)
@@ -301,7 +301,7 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-            "calldata is Multicall.run([wrapperActionsAddress, cometRepayAndWithdrawMultipleAssetsAddress], [WrapperActions.wrapWETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, 1e18), CometRepayAndWithdrawMultipleAssets.run(COMET_1_WETH, collateralTokens, collateralAmounts, weth_(1), 1e18)"
+            "calldata is Multicall.run([wrapperActionsAddress, cometRepayAndWithdrawMultipleAssetsAddress], [WrapperActions.wrapAllETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2), CometRepayAndWithdrawMultipleAssets.run(COMET_1_WETH, collateralTokens, collateralAmounts, weth_(1), 1e18)"
         );
         assertEq(result.quarkOperations[0].scriptSources.length, 3);
         assertEq(result.quarkOperations[0].scriptSources[0], type(WrapperActions).creationCode);

--- a/test/builder/QuarkBuilderCometSupply.t.sol
+++ b/test/builder/QuarkBuilderCometSupply.t.sol
@@ -306,12 +306,12 @@ contract QuarkBuilderCometSupplyTest is Test, QuarkBuilderTest {
         callContracts[1] = cometSupplyActionsAddress;
         bytes[] memory callDatas = new bytes[](2);
         callDatas[0] =
-            abi.encodeWithSelector(WrapperActions.wrapETH.selector, 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, 1e18);
+            abi.encodeWithSelector(WrapperActions.wrapAllETH.selector, 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
         callDatas[1] = abi.encodeCall(CometSupplyActions.supply, (COMET_ETH, weth_(1), 1e18));
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-            "calldata is Multicall.run([wrapperActionsAddress, cometSupplyActionsAddress], [WrapperActions.wrapWETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, 1e18), CometSupplyActions.supply(COMET_ETH, weth_(1), 1e18)"
+            "calldata is Multicall.run([wrapperActionsAddress, cometSupplyActionsAddress], [WrapperActions.wrapAllETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2), CometSupplyActions.supply(COMET_ETH, weth_(1), 1e18)"
         );
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 3 days"

--- a/test/builder/QuarkBuilderMorphoBorrow.t.sol
+++ b/test/builder/QuarkBuilderMorphoBorrow.t.sol
@@ -234,7 +234,7 @@ contract QuarkBuilderMorphoBorrowTest is Test, QuarkBuilderTest {
         callContracts[1] = MorphoActionsAddress;
         bytes[] memory callDatas = new bytes[](2);
         callDatas[0] = abi.encodeWithSelector(
-            WrapperActions.wrapETH.selector, TokenWrapper.getKnownWrapperTokenPair(8453, "WETH").wrapper, 1e18
+            WrapperActions.wrapAllETH.selector, TokenWrapper.getKnownWrapperTokenPair(8453, "WETH").wrapper
         );
         callDatas[1] = abi.encodeCall(
             MorphoActions.supplyCollateralAndBorrow,
@@ -244,7 +244,7 @@ contract QuarkBuilderMorphoBorrowTest is Test, QuarkBuilderTest {
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-            "calldata is Multicall.run([wrapperActionsAddress, MorphoActionsAddress], [WrapperActions.wrapWETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, 10e18), MorphoActions.supplyCollateralAndBorrow(MorphoInfo.getMorphoAddress(8453), MorphoInfo.getMarketParams(8453, WETH, USDC), 1e18, 1e6, address(0xa11ce), address(0xa11ce))"
+            "calldata is Multicall.run([wrapperActionsAddress, MorphoActionsAddress], [WrapperActions.wrapAllETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2), MorphoActions.supplyCollateralAndBorrow(MorphoInfo.getMorphoAddress(8453), MorphoInfo.getMarketParams(8453, WETH, USDC), 1e18, 1e6, address(0xa11ce), address(0xa11ce))"
         );
         assertEq(result.quarkOperations[0].scriptSources.length, 3);
         assertEq(result.quarkOperations[0].scriptSources[0], type(WrapperActions).creationCode);

--- a/test/builder/QuarkBuilderMorphoRepay.t.sol
+++ b/test/builder/QuarkBuilderMorphoRepay.t.sol
@@ -246,7 +246,7 @@ contract QuarkBuilderMorphoRepayTest is Test, QuarkBuilderTest {
         callContracts[1] = morphoActionsAddress;
         bytes[] memory callDatas = new bytes[](2);
         callDatas[0] = abi.encodeWithSelector(
-            WrapperActions.wrapETH.selector, TokenWrapper.getKnownWrapperTokenPair(8453, "WETH").wrapper, 1e18
+            WrapperActions.wrapAllETH.selector, TokenWrapper.getKnownWrapperTokenPair(8453, "WETH").wrapper
         );
         callDatas[1] = abi.encodeCall(
             MorphoActions.repayAndWithdrawCollateral,
@@ -256,7 +256,7 @@ contract QuarkBuilderMorphoRepayTest is Test, QuarkBuilderTest {
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-            "calldata is Multicall.run([wrapperActionsAddress, morphoActionsAddress], [WrapperActions.wrapWETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, 1e18),  MorphoActions.repayAndWithdrawCollateral(MorphoInfo.getMorphoAddress(8453), MorphoInfo.getMarketParams(8453, WETH, USDC), 1e18, 0, 0e18, address(0xa11ce), address(0xa11ce))"
+            "calldata is Multicall.run([wrapperActionsAddress, morphoActionsAddress], [WrapperActions.wrapAllETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2),  MorphoActions.repayAndWithdrawCollateral(MorphoInfo.getMorphoAddress(8453), MorphoInfo.getMarketParams(8453, WETH, USDC), 1e18, 0, 0e18, address(0xa11ce), address(0xa11ce))"
         );
         assertEq(result.quarkOperations[0].scriptSources.length, 3);
         assertEq(result.quarkOperations[0].scriptSources[0], type(WrapperActions).creationCode);

--- a/test/builder/QuarkBuilderMorphoVaultSupply.t.sol
+++ b/test/builder/QuarkBuilderMorphoVaultSupply.t.sol
@@ -320,13 +320,13 @@ contract QuarkBuilderMorphoVaultTest is Test, QuarkBuilderTest {
         callContracts[1] = morphoVaultActionsAddress;
         bytes[] memory callDatas = new bytes[](2);
         callDatas[0] =
-            abi.encodeWithSelector(WrapperActions.wrapETH.selector, 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, 1e18);
+            abi.encodeWithSelector(WrapperActions.wrapAllETH.selector, 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
         callDatas[1] =
             abi.encodeCall(MorphoVaultActions.deposit, (MorphoInfo.getMorphoVaultAddress(1, "WETH"), weth_(1), 1e18));
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-            "calldata is Multicall.run([wrapperActionsAddress, morphoVaultActionsAddress], [WrapperActions.wrapWETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, 1e18), MorphoVaultActions.deposit(MorphoInfo.getMorphoVaultAddress(1, WETH), weth_(1), 1e18)"
+            "calldata is Multicall.run([wrapperActionsAddress, morphoVaultActionsAddress], [WrapperActions.wrapAllETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2), MorphoVaultActions.deposit(MorphoInfo.getMorphoVaultAddress(1, WETH), weth_(1), 1e18)"
         );
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 3 days"

--- a/test/builder/QuarkBuilderSwap.t.sol
+++ b/test/builder/QuarkBuilderSwap.t.sol
@@ -283,13 +283,13 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
         callContracts[1] = approveAndSwapAddress;
         bytes[] memory callDatas = new bytes[](2);
         callDatas[0] =
-            abi.encodeWithSelector(WrapperActions.wrapETH.selector, 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, 1e18);
+            abi.encodeWithSelector(WrapperActions.wrapAllETH.selector, 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
         callDatas[1] =
             abi.encodeCall(ApproveAndSwap.run, (ZERO_EX_ENTRY_POINT, WETH_1, 1e18, USDC_1, 3000e6, ZERO_EX_SWAP_DATA));
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-            "calldata is Multicall.run([wrapperActionsAddress, approveAndSwapAddress], [WrapperActions.wrapWETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, 1e18), ApproveAndSwap.run (ZERO_EX_ENTRY_POINT, WETH_1, 1e18, USDC_1, 3000e6,  ZERO_EX_SWAP_DATA)]);"
+            "calldata is Multicall.run([wrapperActionsAddress, approveAndSwapAddress], [WrapperActions.wrapAllETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2), ApproveAndSwap.run (ZERO_EX_ENTRY_POINT, WETH_1, 1e18, USDC_1, 3000e6,  ZERO_EX_SWAP_DATA)]);"
         );
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 3 days, "expiry is current blockTimestamp + 3 days"

--- a/test/builder/QuarkBuilderTransfer.t.sol
+++ b/test/builder/QuarkBuilderTransfer.t.sol
@@ -1066,8 +1066,8 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
             morphoVaultPositions: emptyMorphoVaultPositions_()
         });
 
-        // Transfer 1.5ETH to 0xceecee on chain 1
-        // Should able to have auto unwrapping 0.5 WETH to ETH to cover the amount
+        // Transfer 1.5 ETH to 0xceecee on chain 1
+        // Should unwrap up to 1.5 WETH to ETH to cover the amount (0.5 WETH will actually be unwrapped)
         QuarkBuilder.BuilderResult memory result = builder.transfer(
             transferEth_(1, 1.5e18, address(0xceecee), BLOCK_TIMESTAMP), chainAccountsList, paymentUsd_()
         );
@@ -1089,13 +1089,14 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         callContracts[0] = wrapperActionsAddress;
         callContracts[1] = transferActionsAddress;
         bytes[] memory callDatas = new bytes[](2);
-        callDatas[0] =
-            abi.encodeWithSelector(WrapperActions.unwrapAllWETH.selector, 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
+        callDatas[0] = abi.encodeWithSelector(
+            WrapperActions.unwrapWETHUpTo.selector, 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, 1.5e18
+        );
         callDatas[1] = abi.encodeWithSelector(TransferActions.transferNativeToken.selector, address(0xceecee), 1.5e18);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-            "calldata is Multicall.run([wrapperActionsAddress, transferActionsAddress], [WrapperActions.unwrapAllWETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2), TransferActions.transferNativeToken(address(0xceecee), 1.5e18)]);"
+            "calldata is Multicall.run([wrapperActionsAddress, transferActionsAddress], [WrapperActions.unwrapWETHUpTo(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, 1.5e18), TransferActions.transferNativeToken(address(0xceecee), 1.5e18)]);"
         );
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
@@ -1172,8 +1173,8 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
             morphoVaultPositions: emptyMorphoVaultPositions_()
         });
 
-        // Transfer 1.5ETH to 0xceecee on chain 1
-        // Should able to have auto unwrapping 0.5 WETH to ETH to cover the amount
+        // Transfer 1.5 ETH to 0xceecee on chain 1
+        // Should unwrap up to 1.5 WETH to ETH to cover the amount (0.5 WETH will actually be unwrapped)
         QuarkBuilder.BuilderResult memory result = builder.transfer(
             transferEth_(1, 1.5e18, address(0xceecee), BLOCK_TIMESTAMP), chainAccountsList, paymentUsdc_(maxCosts)
         );
@@ -1198,8 +1199,9 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         callContracts[0] = wrapperActionsAddress;
         callContracts[1] = transferActionsAddress;
         bytes[] memory callDatas = new bytes[](2);
-        callDatas[0] =
-            abi.encodeWithSelector(WrapperActions.unwrapAllWETH.selector, 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
+        callDatas[0] = abi.encodeWithSelector(
+            WrapperActions.unwrapWETHUpTo.selector, 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, 1.5e18
+        );
         callDatas[1] = abi.encodeWithSelector(TransferActions.transferNativeToken.selector, address(0xceecee), 1.5e18);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
@@ -1209,7 +1211,7 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
                 abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
                 1e5
             ),
-            "calldata is Paycall.run(Multicall.run([wrapperActionsAddress, transferActionsAddress], [WrapperActions.unwrapAllWETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2), TransferActions.transferNativeToken(address(0xceecee), 1.5e18)]), 1e5);"
+            "calldata is Paycall.run(Multicall.run([wrapperActionsAddress, transferActionsAddress], [WrapperActions.unwrapWETHUpTo(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, 1.5e18), TransferActions.transferNativeToken(address(0xceecee), 1.5e18)]), 1e5);"
         );
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
@@ -1286,8 +1288,8 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
             morphoVaultPositions: emptyMorphoVaultPositions_()
         });
 
-        // Transfer max ETH to 0xceecee on chain 1
-        // Should able to have auto unwrapping 0.5 WETH to ETH to cover the amount
+        // Transfer max (2) ETH to 0xceecee on chain 1
+        // Should unwrap up to 2 WETH to ETH to cover the amount (1 WETH will actually be unwrapped)
         QuarkBuilder.BuilderResult memory result = builder.transfer(
             transferEth_(1, type(uint256).max, address(0xceecee), BLOCK_TIMESTAMP),
             chainAccountsList,
@@ -1314,8 +1316,9 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         callContracts[0] = wrapperActionsAddress;
         callContracts[1] = transferActionsAddress;
         bytes[] memory callDatas = new bytes[](2);
-        callDatas[0] =
-            abi.encodeWithSelector(WrapperActions.unwrapAllWETH.selector, 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
+        callDatas[0] = abi.encodeWithSelector(
+            WrapperActions.unwrapWETHUpTo.selector, 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, 2e18
+        );
         callDatas[1] = abi.encodeWithSelector(TransferActions.transferNativeToken.selector, address(0xceecee), 2e18);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
@@ -1325,7 +1328,7 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
                 abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
                 1e5
             ),
-            "calldata is Quotecall.run(Multicall.run([wrapperActionsAddress, transferActionsAddress], [WrapperActions.unwrapAllWETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2), TransferActions.transferNativeToken(address(0xceecee), 2e18)]), 1e5);"
+            "calldata is Quotecall.run(Multicall.run([wrapperActionsAddress, transferActionsAddress], [WrapperActions.unwrapWETHUpTo(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, 2e18), TransferActions.transferNativeToken(address(0xceecee), 2e18)]), 1e5);"
         );
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"

--- a/test/builder/QuarkBuilderTransfer.t.sol
+++ b/test/builder/QuarkBuilderTransfer.t.sol
@@ -1093,14 +1093,13 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         callContracts[0] = wrapperActionsAddress;
         callContracts[1] = transferActionsAddress;
         bytes[] memory callDatas = new bytes[](2);
-        callDatas[0] = abi.encodeWithSelector(
-            WrapperActions.unwrapWETH.selector, 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, 0.5e18
-        );
+        callDatas[0] =
+            abi.encodeWithSelector(WrapperActions.unwrapAllWETH.selector, 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
         callDatas[1] = abi.encodeWithSelector(TransferActions.transferNativeToken.selector, address(0xceecee), 1.5e18);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-            "calldata is Multicall.run([wrapperActionsAddress, transferActionsAddress], [WrapperActions.unwrapWETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, 0.5e18), TransferActions.transferNativeToken(address(0xceecee), 1.5e18)]);"
+            "calldata is Multicall.run([wrapperActionsAddress, transferActionsAddress], [WrapperActions.unwrapAllWETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2), TransferActions.transferNativeToken(address(0xceecee), 1.5e18)]);"
         );
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
@@ -1203,9 +1202,8 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         callContracts[0] = wrapperActionsAddress;
         callContracts[1] = transferActionsAddress;
         bytes[] memory callDatas = new bytes[](2);
-        callDatas[0] = abi.encodeWithSelector(
-            WrapperActions.unwrapWETH.selector, 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, 0.5e18
-        );
+        callDatas[0] =
+            abi.encodeWithSelector(WrapperActions.unwrapAllWETH.selector, 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
         callDatas[1] = abi.encodeWithSelector(TransferActions.transferNativeToken.selector, address(0xceecee), 1.5e18);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
@@ -1215,7 +1213,7 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
                 abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
                 1e5
             ),
-            "calldata is Paycall.run(Multicall.run([wrapperActionsAddress, transferActionsAddress], [WrapperActions.unwrapWETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, 0.5e18), TransferActions.transferNativeToken(address(0xceecee), 1.5e18)]), 1e5);"
+            "calldata is Paycall.run(Multicall.run([wrapperActionsAddress, transferActionsAddress], [WrapperActions.unwrapAllWETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2), TransferActions.transferNativeToken(address(0xceecee), 1.5e18)]), 1e5);"
         );
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
@@ -1321,7 +1319,7 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         callContracts[1] = transferActionsAddress;
         bytes[] memory callDatas = new bytes[](2);
         callDatas[0] =
-            abi.encodeWithSelector(WrapperActions.unwrapWETH.selector, 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, 1e18);
+            abi.encodeWithSelector(WrapperActions.unwrapAllWETH.selector, 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
         callDatas[1] = abi.encodeWithSelector(TransferActions.transferNativeToken.selector, address(0xceecee), 2e18);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
@@ -1331,7 +1329,7 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
                 abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
                 1e5
             ),
-            "calldata is Quotecall.run(Multicall.run([wrapperActionsAddress, transferActionsAddress], [WrapperActions.unwrapWETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, 1e18), TransferActions.transferNativeToken(address(0xceecee), 2e18)]), 1e5);"
+            "calldata is Quotecall.run(Multicall.run([wrapperActionsAddress, transferActionsAddress], [WrapperActions.unwrapAllWETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2), TransferActions.transferNativeToken(address(0xceecee), 2e18)]), 1e5);"
         );
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
@@ -1432,13 +1430,13 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         callContracts[1] = transferActionsAddress;
         bytes[] memory callDatas = new bytes[](2);
         callDatas[0] =
-            abi.encodeWithSelector(WrapperActions.wrapETH.selector, 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, 0.75e18);
+            abi.encodeWithSelector(WrapperActions.wrapAllETH.selector, 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
         callDatas[1] =
             abi.encodeWithSelector(TransferActions.transferERC20Token.selector, WETH_1, address(0xceecee), 1.75e18);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-            "calldata is Multicall.run([wrapperActionsAddress, transferActionsAddress], [WrapperActions.wrapETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, 0.75e18), TransferActions.transferERC20Token(WETH_1, address(0xceecee), 1.75e18)]);"
+            "calldata is Multicall.run([wrapperActionsAddress, transferActionsAddress], [WrapperActions.wrapAllETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2), TransferActions.transferERC20Token(WETH_1, address(0xceecee), 1.75e18)]);"
         );
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"

--- a/test/builder/QuarkBuilderTransfer.t.sol
+++ b/test/builder/QuarkBuilderTransfer.t.sol
@@ -20,10 +20,6 @@ import {PaymentInfo} from "src/builder/PaymentInfo.sol";
 import {QuarkBuilder} from "src/builder/QuarkBuilder.sol";
 import {QuarkBuilderBase} from "src/builder/QuarkBuilderBase.sol";
 import {Quotecall} from "src/Quotecall.sol";
-import {AcrossActions} from "src/AcrossScripts.sol";
-
-import {FFI} from "src/builder/FFI.sol";
-import {AcrossFFI} from "test/builder/mocks/AcrossFFI.sol";
 
 contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
     function transferUsdc_(uint256 chainId, uint256 amount, address recipient, uint256 blockTimestamp)

--- a/test/builder/mocks/AcrossFFI.sol
+++ b/test/builder/mocks/AcrossFFI.sol
@@ -3,7 +3,15 @@ pragma solidity 0.8.27;
 
 import {IAcrossFFI} from "src/interfaces/IAcrossFFI.sol";
 
-contract AcrossFFI is IAcrossFFI {
+library MockAcrossFFIConstants {
+    uint256 public constant GAS_FEE = 1e6;
+    uint256 public constant VARIABLE_FEE_PCT = 0.01e18;
+}
+
+contract MockAcrossFFI is IAcrossFFI {
+    uint256 public constant GAS_FEE = 1e6;
+    uint256 public constant VARIABLE_FEE_PCT = 0.01e18;
+
     function requestAcrossQuote(
         address, /* inputToken */
         address, /* outputToken */
@@ -11,6 +19,6 @@ contract AcrossFFI is IAcrossFFI {
         uint256, /* dstChain */
         uint256 /* amount */
     ) external pure override returns (uint256 gasFee, uint256 variableFeePct) {
-        return (1e6, 0.01e18);
+        return (MockAcrossFFIConstants.GAS_FEE, MockAcrossFFIConstants.VARIABLE_FEE_PCT);
     }
 }


### PR DESCRIPTION
~~We start using the new "wrap up to" scripts for ETH/WETH in the QuarkBuilder. In the case that ETH/WETh is bridged, we also need to always attempt to wrap/unwrap ETH/WETH on the destination chain because the QuarkBuilder cannot know ahead of time if Across will be sending ETH or WETH to the wallet.~~

We implement new `wrap/unwrap all` functions for ETH/WETH and stETH/wstETH. We also update the QuarkBuilder to always wrap/unwrap all (except for WETH, where we use "unwrap up to" because we prefer to preserve a user's WETH balance).